### PR TITLE
Fixed an error in getting-started/python

### DIFF
--- a/docs/getting-started/python.md
+++ b/docs/getting-started/python.md
@@ -58,7 +58,7 @@ Output:
 
 Alternatively, the Python API can also output results as a Pandas data frame:
 ```python
-results = conn.execute('MATCH (a:User)-[f:Follows]->(b:User) RETURN a.name, f.since, b.name;').getAsDF()
+results = conn.execute('MATCH (a:User)-[f:Follows]->(b:User) RETURN a.name, f.since, b.name;').get_as_df()
 print(results)
 ```
 


### PR DESCRIPTION
Hi guys!

There's a slight error in the Python documentation in regards to the pandas example. I changed

```
results = conn.execute('MATCH (a:User)-[f:Follows]->(b:User) RETURN a.name, f.since, b.name;').getAsDF()
print(results)
```

to

```
results = conn.execute('MATCH (a:User)-[f:Follows]->(b:User) RETURN a.name, f.since, b.name;').get_as_df()
print(results)
```