### PR TITLE
Fix and update the example on the rust getting started page

### DIFF
--- a/docs/getting-started/rust.md
+++ b/docs/getting-started/rust.md
@@ -6,19 +6,19 @@ sidebar_position: 6
 The rust API can be used by adding the kuzu crate to your dependencies in `Cargo.toml`:
 ```toml
 [dependencies]
-kuzu = "0.0.6"
+kuzu = "0.0.9"
 ```
 Below is an example to get you started. Full documentation can be found [here](https://docs.rs/kuzu/latest/kuzu/).
 
 The kuzu crate will by default build and statically link kuzu's C++ library from source. You can also link against the dynamic release libraries (see [the docs](https://docs.rs/kuzu/latest/kuzu/#building) for details).
 
 ```rust
-use kuzu::{Database, Connection, Error};
+use kuzu::{Database, Connection, Error, SystemConfig};
 
 fn main() -> Result<(), Error> {
     // Create an empty database and connect to it
-    let db = Database::new("./test");
-    let conn = Connection::new(&db);
+    let db = Database::new("./test", SystemConfig::default())?;
+    let conn = Connection::new(&db)?;
 
     // Create the tables
     conn.query(


### PR DESCRIPTION
Updated to use the new Database constructor which takes a SystemConfig instead of an integer. I also noticed a type error during compilation that's simple, but would have meant that this example wasn't functional before.

Maybe we should change the Cargo.toml example to `cargo add kuzu` like what's on the installation page to avoid having to update the version number.