### PR TITLE
Running CLI on MacOS doc fix

### DIFF
--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -3,9 +3,11 @@ title: Command Line
 sidebar_position: 0
 ---
 
+## Downloading
 The Kùzu Command Line Interface (CLI) is a unified, dependency-free executable, precompiled for Mac, Linux and Windows systems.
-The CLI can be downloaded [here](https://github.com/kuzudb/kuzu/releases/latest) (search for `Assets` on the page and download the correct `kuzu_cli-xxx.zip` file for your platform).
-After the CLI is downloaded and extracted into a directory, you can navigate the directory via your terminal, and set the execute permissions with `chmod +x kuzu`. 
+The CLI can be downloaded [here](https://github.com/kuzudb/kuzu/releases/latest) (search for `Assets` on the page and download the correct `kuzu_cli-xxx.zip` file for your platform). After the CLI is downloaded and extracted into a directory, you can navigate the directory via your terminal, and set the execute permissions with `chmod +x kuzu`. 
+
+## Running the CLI
 You are now ready to run the executable using `./kuzu <db_path>`, where `<db_path>` is the directory for the database files. This path can either point to an existing database or a yet-to-be-created directory, in which case Kùzu will automatically create the directory and initialize an empty database for you.
 If you input `test` as your `<db_path>`, you should see the following prompt:
 
@@ -13,6 +15,15 @@ If you input `test` as your `<db_path>`, you should see the following prompt:
 ./kuzu_shell ./test
 kuzu> 
 ```
+***Note for MacOS users to give permission to run the CLI:*** When you download the CLI to a MacOS platform, 
+MacOS will initially not allow you to run the CLI as it is a binary not downloaded from an AppStore or 
+Apple-identified developer. You need to give explicit permissions to 
+run the CLI binary.  After you try to run the binary for the first time, it will be blocked. 
+Then, navigate to `System Settings > Privacy & Security`. Next, depending on your MacOS version, you have to either go 
+to the `General` tab or `Security` section and you will see a warning: `"kuzu" was blocked from use because it is not from an
+identified developer`. Next to this warning will be an `Allow Anyway` button. Click this button to allow the CLI binary to run.
+
+
 
 Upon launching the CLI, you can enter a Cypher query and press enter to execute it. The instructions below outline how to load nodes and rels from CSV files and how to run a Cypher query:
 - Create the schema:

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -4,7 +4,7 @@ sidebar_position: 0
 ---
 
 The Kùzu Command Line Interface (CLI) is a unified, dependency-free executable, precompiled for Mac, Linux and Windows systems.
-The CLI can be downloaded [here](https://github.com/kuzudb/kuzu/releases/latest).
+The CLI can be downloaded [here](https://github.com/kuzudb/kuzu/releases/latest) (search for `Assets` on the page and download the correct `kuzu_cli-xxx.zip` file for your platform).
 After the CLI is downloaded and extracted into a directory, you can navigate the directory via your terminal, and set the execute permissions with `chmod +x kuzu`. 
 You are now ready to run the executable using `./kuzu <db_path>`, where `<db_path>` is the directory for the database files. This path can either point to an existing database or a yet-to-be-created directory, in which case Kùzu will automatically create the directory and initialize an empty database for you.
 If you input `test` as your `<db_path>`, you should see the following prompt:


### PR DESCRIPTION
Adding documentation to allow the CLI binary to run on MacOS.