### PR TITLE
Docs base URL remaster

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -25,11 +25,13 @@ jobs:
           path: kuzudb.github.io
         
       - name: Remove old documentations
-        run: rm -rf kuzudb.github.io/docusaurus
+        run: |
+          rm -rf kuzudb.github.io/docusaurus
+          rm -rf kuzudb.github.io/docs
         
       - name: Move new documentations
         run: |
-          mv build kuzudb.github.io/docusaurus
+          mv build kuzudb.github.io/docs
           
         
       - name: Push changes

--- a/blog/2023-02-13-kuzu-v-0.0.2.md
+++ b/blog/2023-02-13-kuzu-v-0.0.2.md
@@ -67,7 +67,7 @@ train graph convolutional or neural networks (GCNs or GNNs), make some node prop
 or link predictions and save them back in Kùzu so you can query these predictions.
 
 ### NetworkX: `QueryResult.get_as_networkx()` function
-Our [Python API](https://kuzudb.com/docs/client-apis/python-api/overview.html) now has a 
+Our [Python API](/docs/client-apis/python.html) now has a 
 new [`QueryResult.get_as_networkx()`](https://kuzudb.com/api-docs/python/kuzu/query_result.html#QueryResult.get_as_networkx) function that can convert query results
 that contain nodes and relationships into NetworkX directed or undirected graphs. Using this function, you can build pipelines
 that benefits from Kùzu's DBMS functionalities (e.g., querying, data extraction and transformations,
@@ -82,11 +82,11 @@ values back as new node properties in Kùzu and query them.
 
 ## Data Import from and Export to Parquet and Arrow
 We have removed our own CSV reader and instead now use [Arrow](https://arrow.apache.org/)
-as our default library when bulk importing data through [`COPY FROM` statements](https://kuzudb.com/docs/data-import/csv-import.html). 
+as our default library when bulk importing data through [`COPY FROM` statements](/docs/data-import/csv-import.html). 
 Using Arrow, we can not only bulk import
 from CSV files but also from arrow IPC and parquet files. We detect the file type
 from the suffix of the file; so if the query says `COPY user FROM ./user.parquet`,
-we infer that this is a parquet file and parse it so. See the details [here](/docusaurus/data-import/parquet-import).
+we infer that this is a parquet file and parse it so. See the details [here](/docs/data-import/parquet-import).
 
 ## Multi-labeled or Unlabeled Queries
 A very useful feature of the query languages of GDBMSs is their
@@ -136,18 +136,18 @@ We've added two important features to enhance Kùzu's ability to store and proce
 
 1) Support of UTF-8 characters. With the help of [utf8proc](https://github.com/JuliaStrings/utf8proc), you can now store string node/relationship
    properties in Kùzu that has UTF-8 characters;
-2) Support of [regex pattern matching](/docusaurus/cypher/expressions/pattern-matching) with strings. Kùzu now supports Cypher's `=~` operator for regex searches, which will return true if its pattern mathces the entire input string. For example: `RETURN 'abc' =~ '.*(b|d).*';`.
+2) Support of [regex pattern matching](/docs/cypher/expressions/pattern-matching) with strings. Kùzu now supports Cypher's `=~` operator for regex searches, which will return true if its pattern matches the entire input string. For example: `RETURN 'abc' =~ '.*(b|d).*';`.
 
 ### CASE Expression
-We've added [CASE](/docusaurus/cypher/expressions/case-expression) for conditional expressions.
-Two forms ([Simple Form](/docusaurus/cypher/expressions/case-expression#simple-form) and [General Form](/docusaurus/cypher/expressions/case-expression#general-form)) of CASE expression are supported.
+We've added [CASE](/docs/cypher/expressions/case-expression) for conditional expressions.
+Two forms ([Simple Form](/docs/cypher/expressions/case-expression#simple-form) and [General Form](/docs/cypher/expressions/case-expression#general-form)) of CASE expression are supported.
 
 ### ALTER/DROP/SET/DELETE
-We added [ALTER TABLE](/cypher/data-definition/alter) and [DROP TABLE](/cypher/data-definition/drop) DDL statements.
+We added [ALTER TABLE](/docs/cypher/data-definition/alter) and [DROP TABLE](/docs/cypher/data-definition/drop) DDL statements.
 After creating a new node or relationship table, you can now drop it, rename it, and alter it by adding new columns/properties, 
 renaming or dropping existing columns/properties.
 
-Besides schema level changes, you can change properties of existing nodes/rels with [SET](/docusaurus/cypher/data-manipulation-clauses/set) statements, and remove existing nodes/rels with [DELETE](/docusaurus/cypher/data-manipulation-clauses/delete) statements.
+Besides schema level changes, you can change properties of existing nodes/rels with [SET](/docs/cypher/data-manipulation-clauses/set) statements, and remove existing nodes/rels with [DELETE](/docs/cypher/data-manipulation-clauses/delete) statements.
 
 ### Disable Relationships with Multiple Source or Destination Labels
 We now no longer support defining a relationship between multiple source or destination labels.

--- a/blog/2023-07-10-kuzu-v-0.0.5.md
+++ b/blog/2023-07-10-kuzu-v-0.0.5.md
@@ -42,7 +42,7 @@ MATCH p1 = (a:User)-[:Follows]->(b:User), p2 = (b)-[:LivesIn]->(:City)
 WHERE a.name = 'Adam' 
 RETURN p1, p2;
 ```
-Internally, a path is processed as a `STRUCT` with two fields, a nodes field with key `_NODES` and type `LIST[NODE]` and a rels field with key `_RELS` and type `LIST[REL]`. See [`PATH`](https://kuzudb.com/docusaurus/cypher/data-types/path) for details. Users can access nodes and rels field with `nodes(p)` and `rels(p)` function calls as follows:
+Internally, a path is processed as a `STRUCT` with two fields, a nodes field with key `_NODES` and type `LIST[NODE]` and a rels field with key `_RELS` and type `LIST[REL]`. See [`PATH`](/docs/cypher/data-types/path) for details. Users can access nodes and rels field with `nodes(p)` and `rels(p)` function calls as follows:
 ```
 MATCH p = (a:User)-[:Follows*1..2]->(:User) 
 WHERE a.name = 'Adam' 
@@ -66,7 +66,7 @@ MATCH p = (a)-[* ALL SHORTEST 1..3]-(b)
 WHERE a.name = 'Zhang' AND b.name = 'Waterloo' 
 RETURN p;
 ```
-See [All Shortest Paths](https://kuzudb.com/docusaurus/cypher/query-clauses/match#all-shortest-path) on our documentation for more information.
+See [All Shortest Paths](/docs/cypher/query-clauses/match#all-shortest-path) on our documentation for more information.
 
 ### `Call` Clause
 
@@ -92,7 +92,7 @@ CALL table_info('User') WITH * WHERE name STARTS WITH 'a' RETURN name;
 --------
 ```
 
-More built in procedures can be found [here](https://kuzudb.com/docusaurus/cypher/query-clauses/call).
+More built in procedures can be found [here](/docs/cypher/query-clauses/call).
 
 ## Modifying Database Configurations
 
@@ -101,7 +101,7 @@ More built in procedures can be found [here](https://kuzudb.com/docusaurus/cyphe
 CALL THREADS=5;
 ```
 
-More configuration options can be found [here](https://kuzudb.com/docusaurus/cypher/configuration).
+More configuration options can be found [here](/docs/cypher/configuration).
 
 ## Data Types
 
@@ -118,10 +118,10 @@ RETURN BLOB('\\xBC\\xBD\\xBA\\xAA') as result;
 ---------------------------------------------
 ```
 
-More information on the blob data type can be found [here](https://kuzudb.com/docusaurus/cypher/data-types/blob).
+More information on the blob data type can be found [here](/docs/cypher/data-types/blob).
 
 ## Client APIs: Rust and Java
-In this release, we're expanding the accessibility of Kùzu, bridging the gap with some of the most popular programming languages in the developer community. Specifically, we now have [Rust](https://kuzudb.com/docusaurus/client-apis/rust) and [Java](https://kuzudb.com/docusaurus/client-apis/java) APIs.
+In this release, we're expanding the accessibility of Kùzu, bridging the gap with some of the most popular programming languages in the developer community. Specifically, we now have [Rust](/docs/client-apis/rust) and [Java](/docs/client-apis/java) APIs.
 
 ## Development: Testing Framework
 Starting with this release, we're adding some development guidelines to encourage and facilitate outside contributions from the broader open source community.
@@ -132,5 +132,5 @@ Whenever possible, we route all tests in the end-to-end way through Cypher state
 To this end, we've designed a custom testing framework that enables thorough end-to-end testing via Cypher statements.
 
 Our testing framework draws inspiration from [SQLLogicTest](https://www.sqlite.org/sqllogictest/doc/trunk/about.wiki), albeit with customized syntax tailored to our needs.
-For a more detailed overview of our testing framework, please visit [here](https://kuzudb.com/docusaurus/development/testing-framework).
+For a more detailed overview of our testing framework, please visit [here](/docs/development/testing-framework).
 

--- a/blog/2023-08-16-kuzu-v-0.0.7.md
+++ b/blog/2023-08-16-kuzu-v-0.0.7.md
@@ -27,7 +27,7 @@ We are very happy to release Kùzu 0.0.7 today! This release comes with the foll
 
 For installing the new version, 
 please visit the [download section of our website](https://kuzudb.com/#download) 
-and [getting started guide](https://kuzudb.com/docusaurus/getting-started/). The full
+and [getting started guide](/docs/getting-started/). The full
 [release notes are here](https://github.com/kuzudb/kuzu/releases). 
 
 ## Macro and UDF
@@ -43,10 +43,10 @@ return addWithDefault(2);  // returns 5 (2 + 3)
 // Executes the macro by providing the default value (actual parameter value will be used).
 return addWithDefault(4, 7);  // returns 11 (4 + 7)
 ```
-See more details on supported macro expression types [here](./../cypher/macro).
+See more details on supported macro expression types [here](/docs/cypher/macro).
 
 ### C++ UDFs
-We are also introducing two C++ interfaces, `createScalarFunction` and `createVectorizedFunction` in the `Connection` class of the [C++ API](https://kuzudb.com/docusaurus/getting-started/cpp) to define both scalar and vectorized [UDFs](./../client-apis/cpp-api/udf).
+We are also introducing two C++ interfaces, `createScalarFunction` and `createVectorizedFunction` in the `Connection` class of the [C++ API](/docs/getting-started/cpp) to define both scalar and vectorized [UDFs](/docs/client-apis/cpp-api/udf).
 
 `createScalarFunction` provides a way for users to define scalar functions in C++ and use it in Kùzu as if they're built-in functions.
 Here is an example of a unary scalar function that increments the input value by 5:
@@ -61,7 +61,7 @@ conn->query("MATCH (p:person) return addFiveScalar(to_int32(p.age))");
 ```
 
 For users familiar with internals of our intermediate result representation, they can make use of `createVectorizedFunction` to create vectorized function over our ValueVectors to achieve better performance.
-See [our doc here](./../client-apis/cpp-api/udf) for more details.
+See [our doc here](/docs/client-apis/cpp-api/udf) for more details.
 
 ## Data Update and Return Clauses
 ### Merge Clause
@@ -89,7 +89,7 @@ RETURN e;
 | (0:0)-{_LABEL: Follows, _ID: 0:5, since: 1999}->(0:1) |
 ---------------------------------------------------------
 ```
-See [our doc here](./../cypher/data-manipulation-clauses/merge) for more details.
+See [our doc here](/docs/cypher/data-manipulation-clauses/merge) for more details.
 
 ### Multi-label Set/Delete
 
@@ -104,7 +104,7 @@ MATCH ()-[f]->() SET f.since = 2023
 ```
 Note that when evaluating this query, tuples in tables that don't have `since` property will be ignored.
 
-See our docs in [Set](./../cypher/data-manipulation-clauses/set) and [Delete](./../cypher/data-manipulation-clauses/delete) for more details.
+See our docs in [Set](/docs/cypher/data-manipulation-clauses/set) and [Delete](/docs/cypher/data-manipulation-clauses/delete) for more details.
 
 ### Return After Update
 
@@ -131,7 +131,7 @@ RETURN e;
 ---------------------------------------------------------
 ```
 
-See our docs in [Set](./../cypher/data-manipulation-clauses/set) and [Delete](./../cypher/data-manipulation-clauses/delete) for more examples.
+See our docs in [Set](/docs/cypher/data-manipulation-clauses/set) and [Delete](/docs/cypher/data-manipulation-clauses/delete) for more examples.
 
 ### Return with .*
 As a syntactic sugar, Kùzu now supports returning all properties of node or rel with *.
@@ -150,7 +150,7 @@ MATCH (a:User) RETURN a.*;
 -------------------
 ```
 
-See [our doc here](./../cypher/query-clauses/return#returning-node-and-relationship-properties) for more details.
+See [our doc here](/docs/cypher/query-clauses/return#returning-node-and-relationship-properties) for more details.
 
 ## Data Export
 Kùzu now supports exporting query results to CSV files using the `COPY TO` command. For example the following
@@ -166,7 +166,7 @@ u.name,u.age
 "Zhang",50
 "Noura",25
 ```
-See [Data Export](../data-export/) for more information.
+See [Data Export](/docs/data-export/) for more information.
 
 ## New Data Types and APIs
 ### MAP
@@ -181,12 +181,12 @@ RETURN map([1, 2], ['a', 'b']) AS m;
 --------------
 ```
 
-See [map](../cypher/data-types/map) for more information.
+See [MAP](/docs/cypher/data-types/map) for more information.
 
 ### UNION
 Kùzu's `UNION` is implemented by taking DuckDB's `UNION` type as a reference. Similar to C++ `std::variant`, `UNION` is a nested data type that is capable of holding multiple alternative values with different types. The value under key "tag" is considered as the value being currently hold by the `UNION`.
 
-See [union](../cypher/data-types/union) for more information.
+See [UNION](/docs/cypher/data-types/union) for more information.
 
 ### Converting Query Results to Arrow
 In previous releases, we supported converting query result to Arrow tables in our [Python API](https://kuzudb.com/api-docs/python/kuzu/query_result.html#QueryResult.get_as_arrow).

--- a/blog/2024-01-04-llms-graphs-part-1/index.md
+++ b/blog/2024-01-04-llms-graphs-part-1/index.md
@@ -194,7 +194,7 @@ You ultimately construct a string prompt that contains $Q_{NL}$, some
 instructions, and schema of the database, and the LLM will generate a query for you. 
 The `KuzuGraph` and `KuzuQAChain` are simple wrappers to do just that.
 If you want to play around with how well this works on other datasets,
-we have this pipeline implemented in Kùzu's browser frontend [KùzuExplorer](https://kuzudb.com/docusaurus/kuzuexplorer/). 
+we have this pipeline implemented in Kùzu's browser frontend [KùzuExplorer](/docs/kuzuexplorer/). 
 
 That is, for any database you have in Kùzu, you get a natural language interface over it in
 KùzuExplorer (just click the "robot icon" on the left panel). 

--- a/blog/2024-01-15-llms-graphs-part-2/index.md
+++ b/blog/2024-01-15-llms-graphs-part-2/index.md
@@ -16,7 +16,7 @@ import TriplesBasedRAGOverview from './triples-based-rag-overview.png';
 
 # RAG Using Unstructured Data & Role of Knowledge Graphs 
 
-[In my previous post](https://kuzudb.com/docusaurus/blog/llms-graphs-part-1), 
+[In my previous post](/docs/blog/llms-graphs-part-1), 
 I gave an overview of question answering (Q&A) systems that use LLMs
 over private enterprise data. I covered the architectures of these systems, the common tools
 developers use to build these systems when the enterprise data used is structured, 
@@ -50,7 +50,7 @@ its potential benefits should be subjected to rigorously evaluation, e.g., as ma
 :::
 
 ## RAG-U Overview
-I will skip the overview of RAG systems, which I covered in [the previous post](https://kuzudb.com/docusaurus/blog/llms-graphs-part-1#a-note-on-the-term-rag).
+I will skip the overview of RAG systems, which I covered in [the previous post](/docs/blog/llms-graphs-part-1#a-note-on-the-term-rag).
 The picture of RAG systems that use unstructured data looks as follows:
 <div class="img-center">
 <img src={RAGUsingUnstructuredData} width="600"/>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,7 +17,7 @@ const config = {
   url: "https://kuzudb.com",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: "/docusaurus/",
+  baseUrl: "/docs/",
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
@@ -99,7 +99,7 @@ const config = {
             type: "html",
             position: "right",
             value: `
-            <a href="https://discord.gg/jw7xN2ZhJB" class="navbar__link navbar__link--social">
+            <a href="https://discord.gg/CV7FVsPeVz" class="navbar__link navbar__link--social">
               <i class="fa-brands fa-discord fa-xl"></i>
             </a>
             `,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4432,9 +4432,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001508",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001508.tgz",
-      "integrity": "sha512-sdQZOJdmt3GJs1UMNpCCCyeuS2IEGLXnHyAo9yIO5JJDjbjoVRij4M1qep6P6gFpptD1PqIYgzM+gwJbOi92mw==",
+      "version": "1.0.30001579",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz",
+      "integrity": "sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,5 +2,5 @@ import React from 'react';
 import  { Redirect } from 'react-router-dom';
 
 export default function Home() {
-  return <Redirect to='/docusaurus/getting-started/' />;
+  return <Redirect to='/docs/getting-started/' />;
 }


### PR DESCRIPTION
## Purpose of PR

The current base URL of the Kùzu docs aren't very Google search-friendly. When you type "Kuzu docs" in google, the documentation page basically doesn't even show up, because the base URL is set as `docusaurus`. My take is that when Google indexes pages, it looks for terms like "documentation" or "docs" in the metadata of the page header or the URL itself. In our case, it's `docusaurus`, so the google crawler doesn't seem to index the entire documentation website correctly.

The following is what you obtain (more or less) when you type "Kuzu docs" into Google search. As can be seen, **none** of the top 6 results are useful, as none of them leads you directly to the documentation, which is what you'd want as a user.

![image](https://github.com/kuzudb/kuzu-docs/assets/35005448/ebe54818-efac-45ed-8a3c-19bd8d577a1d)

## Fix

The base URL should be `docs`, as this gives a much more intuitive url that google can hopefully index better: `https://kuzudb.com/docs`.

## How has this been tested?

I went through all the documents where we make a direct URL reference to `https://kuzudb.com/docusaurus` and replaced it with relative URLs `/docs` instead.

On my local server, I checked that all mouse-clicks on the relative URLs lead back to the same documentation pages, with no broken links to the best of my knowledge.

I think this would help improve SEO and lead users much more easily to our documentation page once they start using Kùzu.