### PR TITLE
Add docs keywords to global metadata

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -162,6 +162,10 @@ const config = {
       },
       metadata: [
         {
+          name: "keywords",
+          content: "graph database, graph db, docs, documentation",
+        }
+        {
           name: "og:locale",
           content: "en_US",
         },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -164,7 +164,7 @@ const config = {
         {
           name: "keywords",
           content: "graph database, graph db, docs, documentation",
-        }
+        },
         {
           name: "og:locale",
           content: "en_US",


### PR DESCRIPTION
Adding keywords to global metadata for better discoverability and SEO as per [the docs](https://docusaurus.io/docs/seo#global-metadata).