### PR TITLE
List operators: IN, + and [:]

### DIFF
--- a/src/content/docs/cypher/expressions/index.mdx
+++ b/src/content/docs/cypher/expressions/index.mdx
@@ -60,6 +60,10 @@ Click on the cards below to learn more about the available functions, operators 
     title="NULL operators"
     href="/cypher/expressions/null-operators"
   />
+  <LinkCard
+    title="List operators"
+    href="/cypher/expressions/list-operators"
+  />
 </CardGrid>
 
 ---

--- a/src/content/docs/cypher/expressions/list-functions.md
+++ b/src/content/docs/cypher/expressions/list-functions.md
@@ -3,14 +3,9 @@ title: List Functions
 description: List functions are used to create and manipulate lists.
 ---
 
-List functions are used to create and manipulate lists. First, let's see the list operators that can be used with lists.
-
-| Operator | Description | Example | Result |
-| ----------- | ----------- |  ----------- |  ----------- |
-| IN | operator for the `list_contains` function | `1 IN [1,2,3]` | `true` |
+List functions are used to create and manipulate lists.
 
 :::caution[Note]
-The following table shows the functions that are used in the list operations.
 Scroll to the right to see the example usage in the below table.
 :::
 

--- a/src/content/docs/cypher/expressions/list-operators.md
+++ b/src/content/docs/cypher/expressions/list-operators.md
@@ -5,8 +5,12 @@ description: List functions are used to create and manipulate lists.
 
 The following table shows the operators that can be used with lists.
 
+<div class="scroll-table">
+
 | Operator | Description | Example | Result |
-| ----------- | ----------- |  ----------- |  ----------- |
-| + | concatenates two lists | `RETURN [1,2,3] + [4,5] AS mylist` | `[1,2,3,4,5]` |
-| [start:stop] | accessing elements in a list | `WITH [1,2,3,4,5] AS mylist RETURN mylist[1:3]` | `[1,2]` |
-| IN | operator for the `list_contains` function | `1 IN [1,2,3]` | `true` |
+| :----------- | ----------- |  ----------- |  ----------- |
+| `+` | concatenates two lists | `RETURN [1,2,3] + [4,5] AS mylist` | `[1,2,3,4,5]` |
+| `[start:stop]` | access specific elements in a list | `WITH [1,2,3,4,5] AS mylist RETURN mylist[1:3]` | `[1,2]` |
+| `IN` | operator for the `list_contains` function | `1 IN [1,2,3]` | `true` |
+
+</div>

--- a/src/content/docs/cypher/expressions/list-operators.md
+++ b/src/content/docs/cypher/expressions/list-operators.md
@@ -1,0 +1,12 @@
+---
+title: List Functions
+description: List functions are used to create and manipulate lists.
+---
+
+The following table shows the operators that can be used with lists.
+
+| Operator | Description | Example | Result |
+| ----------- | ----------- |  ----------- |  ----------- |
+| + | concatenates two lists | `RETURN [1,2,3] + [4,5] AS mylist` | `[1,2,3,4,5]` |
+| [start:stop] | accessing elements in a list | `WITH [1,2,3,4,5] AS mylist RETURN mylist[1:3]` | `[1,2]` |
+| IN | operator for the `list_contains` function | `1 IN [1,2,3]` | `true` |


### PR DESCRIPTION
This PR moves the `IN` operator description to be in a separate section, called "List operators". The `IN` operator is a common one that people use to check for presence of an element in a list. The `+` operator and `[start:stop]` are also added, to be more in line with [Neo4j's docs on this](https://neo4j.com/docs/cypher-manual/current/syntax/operators/#query-operators-list). Hope this makes sense.