### PR TITLE
Add intro YouTube video to homepage

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -6,8 +6,6 @@ template: doc
 
 Welcome to the Kùzu docs!
 
-<!-- Insert 3-min intro to Kùzu YT video embed here when it's ready -->
-
 Kùzu is an embedded graph database built for query speed and scalability. It is optimized for
 handling complex join-heavy analytical workloads on very large graphs, with the following core
 feature set:
@@ -21,6 +19,19 @@ feature set:
 - Novel and very fast join algorithms
 - Multi-core query parallelism
 - Serializable ACID transactions
+
+If you're new to Kùzu and graph databases, we recommend starting with this
+introductory video. Once you're ready to dive in, check out the rest of the documentation!
+
+<div class="video-container">
+  <iframe
+    height="480"
+    src="https://www.youtube.com/embed/BksVyv5864k?si=DOBmVy_1-Ng2c5Lq"
+    title="YouTube video player" frameborder="0"
+    allowfullscreen
+    >
+  </iframe>
+</div>
 
 ## Why Kùzu
 

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -180,3 +180,16 @@ https://github.com/withastro/starlight/blob/main/packages/starlight/style/props.
 	border-color: var(--sl-color-green);
 	background-color: var(--sl-color-green-low);
 }
+
+.video-container {
+    position: relative;
+    padding-bottom: 56.25%; /* 16:9 */
+    height: 0;
+  }
+  .video-container iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }


### PR DESCRIPTION
Closes #156.

This PR embeds our intro to graph databases YouTube video in the homepage.