### PR TITLE
join order hint edits

### DIFF
--- a/src/content/docs/developer-guide/join-order-hint.md
+++ b/src/content/docs/developer-guide/join-order-hint.md
@@ -80,6 +80,8 @@ HINT (((a JOIN e1) JOIN b) MULTI_JOIN e2 MULTI_JOIN e3) JOIN c
 RETURN COUNT(*)
 ```
 
-*Note: If in your `HINT` you use `MULTI_JOIN` with a single relation, i.e., when k-1 is 1, then this will not produce
+:::note[Note]
+If in your `HINT` you use `MULTI_JOIN` with a single relation, i.e., when k-1 is 1, then this will not produce
 a plan with a WCOJ operator because to perform intersections, there needs to be at least 2 sets of adjacency lists to intersect.
 Instead `MULTI_JOIN` will be treated as JOIN.
+:::

--- a/src/content/docs/developer-guide/join-order-hint.md
+++ b/src/content/docs/developer-guide/join-order-hint.md
@@ -3,44 +3,83 @@ title: Join order hints
 description: Join order hint that allow users to enforce a specific join order
 ---
 
-`HINT` is an optional clause allows you to enforce a specific query plan by explicitly declaring the join order or
-the join strategy. See below for the available hints for Kùzu 0.5.0 and upward.
+`HINT` is an optional clause, available since Kùzu 0.5.0 and upward, that allows you to enforce a specific query plan 
+for some of your queries. Specifically, you can explicitly declare the join order and/or sometimes the
+join algorithm used by the system. 
 
-## Join order hint
+## HINT and JOIN clauses
 
-Consider the following query
-```cypher
+We explain the `HINT` clause through an example. Consider the following query:
+```
 MATCH (a:person)-[e:LivesIn]->(b:City)
+WHERE b.ID = 0
 RETURN *;
 ```
-The system optimizer has its freedom to generate a query plan that finds all edges from `a` to `b` using forward adjacency list or from `b` to `a` using a backward adjacency list. Both query plans are semantically equivalent and generate the same query result. There is, however, a potential performance difference because `a` and `b` may have different cardinalities.
+The Kùzu optimizer has the freedom to generate a query plan that matches all relationships from `a` to `b` using 
+forward adjacency lists or from `b` to `a` using a backward adjacency lists. 
+Both query plans are correct and will generate the same query result. However, there is a potential performance difference because 
+there may be different number of nodes matching to `a` and `b`, i.e., `a` and `b` may have different cardinalities.
+In the above case because there is a filter on b, you can expect there to be very few, possibly only 1 `b` node that matches the predicate in the `WHERE` clause.
 
-To enforce a particular join order (you may want to do this for experimental purposes, or when the optimizer provides a sub-optimal plan), use `HINT` and write a join order with the following rules:
-- Join hints work within the scope of a single `MATCH` pattern. Hints across different join patterns is not supported.
-- All node/relationship variable must be named and appear in the join order
-- The join order is a binary tree where the tree node is either a variable or a sub-join order tree enclosed in parentheses
+For experimental purposes, or when the optimizer provides a sub-optimal plan, you can enforce a particular join order 
+by using the `HINT` clause and writing a join order. This works as follows:
+- Join hints work within the scope of a single `MATCH` pattern.
+- The pattern must be connected, e.g., it cannot be `MATCH (a:Person), (b:Person) RETURN *;` where there are 2 disconnected components.
+- Every node/relationship variable must be named and appear in the join order exactly once. Relationship variables can be [recursive](https://docs.kuzudb.com/cypher/query-clauses/match/#match-variable-lengthrecursive-relationships), e.g., `-[e*1..3]->` or `-[e* SHORTEST]->`.
+- The join order is a binary tree, expressed through the structure of the parentheses inside the `HINT` clause. Every sub-tree in the plan specified by `HINT` must be connected.
 
-
-For example, we can enforce a query plan that scans from `b` with a backward adjacency list as follows:
-```cypher
+As an example, the below hint enforces a query plan that scans edges using backward adjacency lists from `b`:
+```
 MATCH (a)-[e]->(b)
-WHERE a.ID = 0
+WHERE b.ID = 0
 HINT a JOIN (e JOIN b)
 RETURN *;
 ```
+The full parenthesization is this: `(a JOIN (e JOIN b))`. The top join operator joins `a` 
+with the result of `(e JOIN b)`. The `(e JOIN b)` enforces the join of b node records with e, which will happen by scanning the b nodes in the backward direction.
+The result of this will then be joined with `a` node records. If the parenthesization was `((a JOIN e) JOIN b)`, then the
+top join operator would join `(a JOIN e)`, which would be computed by scanning `a` nodes in the forward direction, with `b`. 
 
-### Multi-way join hint
+### Effect of left/right side of JOIN:
+In a single parenthesis that uses the `JOIN` clause swapping the left and right sides of JOIN have an effect. 
+Specifically, `(x JOIN y)` and `(y JOIN x)` will generally (though not always) lead to different plans.
+In both cases `x` and `y` will be joined, however if the JOIN operator is a hash join operator, then the left side
+is the probe and the right side if the build side of the hash join. This can have an impact on performance.
 
-This section assumes you are knowledgeable about worst-case-optimal joins (WCOJ). For cyclic queries, we allow not only binary join hints but also multi-way join (worst-case-optimal-join) hints. When hinting k-way joins, the following rules needs to be satisfied:
+In the case when the parenthesis looks as follows `(a JOIN e1)`, where
+one of these variables is a node variable and the other is a relationship variable, then `(a JOIN e1)` vs `(e1 JOIN a)` produce the
+same plan because such joins are compiled as scanning node table followed by scan relationship tables.
 
-- Use the keyword `MULTI_JOIN` instead of `JOIN`.
-- Within `k` tree nodes, `k-1` of them must be edge variables - these edges must intersect at a single node.
+### MULTI_JOIN clause: Worst-case optimal join plans
 
-When we perform the k-way join between a subplan and `k-1` edges, for each input tuple from the subplan, we find an adjacency list from each edge table and sort-merge join them on the intersected node.
+Kùzu plans can use a combination of binary join operators and [worst-case optimal join (WCOJ)](https://blog.kuzudb.com/post/wcoj/) operators.
+WCOJ operators which
+are useful if your `MATCH` pattern contains cycles, e.g., when finding triangles or larger cliques of nodes in your databases.
+Using HINT, you can also force the optimizer to use a WCOJ operator as follows:
 
-For example, in the following query, we find the forward adjacency list for `e2` and `e3` and intersect them over `c` for each `(a, e1, b)` input.
+- Within `k` tree nodes, `k-1` of them must be edge/relationship variables and not results of more complex sub-join plans. 
+Let us refer to these edges as `e1`, ..., `e(k-1)`. These edges must intersect at a single intersected node variable.
+Let us call that node variable `c`.  The last tree node, which we will call the "probe node" can be the result of an arbitrary sub-join plan.
+Let us refer to the probe node  with `(probeNode)`.
+- Start with the probe side node and list the `k-1` edge variables, all separated with `k-1` `MULTI_JOIN` clauses inside a single paranthesis.
+That is, this component looks like `((probeNode) MULTI_JOIN e1 MULTI_JOIN e2 ... MULTI_JOIN e(k-1))`.
+- Then join this above paranthesis with the intersected node variable `c`. You can do either
+`(((probeNode) MULTI_JOIN e1 MULTI_JOIN e2 ... MULTI_JOIN e(k-1)) JOIN c)` or
+`(c JOIN ((probeNode) MULTI_JOIN e1 MULTI_JOIN e2 ... MULTI_JOIN e(k-1)))`. This changes the build side and probe side
+of how the properties of c, if needed would be placed in the join plan (see above for the details of build and probe sides).
+
+When we perform the k-way join between the probeNode and `k-1` relationships, for each input tuple from the probeNode subplan, we find an adjacency list from each edge table and sort-merge join them on the intersected node.
+That's the essence of the WCOJ operator in Kùzu.
+
+For example, in the following triangle query,  Kùzu will compute `(a JOIN e1)`, which will produce a set of `(a, e1, b)` tuples.
+Then for each `(a, e1, b)` tuple, the Kùzu's WCOJ operator will find the forward adjacency list for `e2` and `e3` and intersect them to
+produce  `(a, e1, b, e2, e3, c)` outputs.
 ```cypher
 MATCH (a:person)<-[e1:knows]-(b:person)-[e2:knows]->(c:person), (a)-[e3:knows]->(c)
 HINT (((a JOIN e1) JOIN b) MULTI_JOIN e2 MULTI_JOIN e3) JOIN c
 RETURN COUNT(*)
 ```
+
+*Note: If in your `HINT` you use `MULTI_JOIN` with a single relation, i.e., when k-1 is 1, then this will not produce
+a plan with a WCOJ operator because to perform intersections, there needs to be at least 2 sets of adjacency lists to intersect.
+Instead `MULTI_JOIN` will be treated as JOIN.


### PR DESCRIPTION
These are my edits for join order hints. I'll open a new branch for my other commits. So @andyfengHKU can take over, do further edits and merge.

Note that I made 3 or 4 assumptions (e.g., the disconnectedness criteria, or left/right of JOIN affecting probe/build side), or that MULTI_JOIN with a single relationship being treated as JOINs (see the very last paragraph). I also opened these issues related to these edits (some of which may be obsolete if they're documentation-related issues and the documentation that I wrote resolves them):

https://github.com/kuzudb/kuzu/issues/4019
https://github.com/kuzudb/kuzu/issues/4020
https://github.com/kuzudb/kuzu/issues/4021
https://github.com/kuzudb/kuzu/issues/4022
https://github.com/kuzudb/kuzu/issues/4023
https://github.com/kuzudb/kuzu/issues/4024

Finally, your call but I suggest removing `_` from `MULTI_JOIN`. I find `_` hard to type.