### PR TITLE
C/C++ linking documentation

### DIFF
--- a/src/content/docs/client-apis/c.mdx
+++ b/src/content/docs/client-apis/c.mdx
@@ -36,7 +36,7 @@ add_executable(example main.c)
 target_link_libraries(example kuzu)
 ```
 
-### Linking against kuzu when built from source
+### Linking against Kùzu when built from source
 
 See the requirements in https://docs.kuzudb.com/developer-guide/.
 It's recommended that you use CMake if you want to link to the kuzu static library as shown in the example below.

--- a/src/content/docs/client-apis/c.mdx
+++ b/src/content/docs/client-apis/c.mdx
@@ -10,3 +10,71 @@ See the following link for the full documentation of the C library API.
   title="C API documentation"
   href="https://kuzudb.com/api-docs/c/kuzu_8h.html"
 />
+
+## Linking
+
+### Using the pre-built library
+
+See [Installation](/installation) and [Get Started](/get-started) for simple manual instructions for building with the C library.
+
+Alternatively, here is an example configuration for integrating the pre-built library into a CMake project (substitute `URL` and `URL_HASH` and `libkuzu.so` as appropriate for your platform).
+```cmake
+cmake_minimum_required(VERSION 3.11)
+project(example LANGUAGES C)
+
+ExternalProject_Add(kuzu-prebuilt
+    URL https://github.com/kuzudb/kuzu/releases/download/v0.5.0/libkuzu-linux-x86_64.tar.gz
+    URL_HASH SHA256=452599a03c4e6accb797d11bd780a2a88629bddf6635b1703993967d31a0467e
+)
+ExternalProject_Get_Property(kuzu-prebuilt SOURCE_DIR)
+add_library(kuzu SHARED IMPORTED)
+add_dependencies(kuzu kuzu-prebuilt)
+set_target_properties(kuzu PROPERTIES IMPORTED_LOCATION ${SOURCE_DIR}/libkuzu.so)
+target_include_directories(kuzu INTERFACE ${SOURCE_DIR})
+
+add_executable(example main.c)
+target_link_libraries(example kuzu)
+```
+
+### Linking against kuzu when built from source
+
+See the requirements in https://docs.kuzudb.com/developer-guide/.
+It's recommended that you use CMake if you want to link to the kuzu static library as shown in the example below.
+
+#### CMake
+
+The following example uses [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) to download and build kuzu as a dependency within a CMake project, and links it either statically or dynamically to an example executable (which can be configured with the `EXAMPLE_SHARED` option). See [Get Started](/get-started) for an example of `main.c`.
+```cmake
+cmake_minimum_required(VERSION 3.11)
+project(example LANGUAGES C CXX)
+
+set(BUILD_SHELL FALSE)
+include(FetchContent)
+FetchContent_Declare(kuzu
+    URL https://github.com/kuzudb/kuzu/archive/refs/tags/v0.5.0.zip
+    URL_HASH SHA256=47ff308079cbbfeccc38eeb1c5f455a8c00f9294034141b9084387518f0bbed9
+)
+FetchContent_MakeAvailable(kuzu)
+
+add_executable(example main.c)
+option(EXAMPLE_SHARED "Use dynamic linking" TRUE)
+if (EXAMPLE_SHARED)
+  target_link_libraries(example kuzu_shared)
+else()
+  target_link_libraries(example kuzu)
+endif()
+```
+
+#### Other Build Systems
+
+Using other build systems with the dynamic library is still relatively simple as all you need to make use of is the dynamic library and kuzu.h, both of which can be installed by CMake. E.g. your build system can run.
+```bash
+cmake -B build
+cmake --build build
+cmake --install build --prefix '<install-dest>'
+```
+And then link against `<install-dest>/libkuzu.so` (or `libkuzu.dylib`/`libkuzu.lib` depending on your platform) and add `<install-dest>` to your include directories.
+
+
+The static library is more complicated (as noted above, it's recommended that you use CMake to handle the details) and is not installed by default, but all static libraries will be available in the build directory.
+You need to define `KUZU_STATIC_DEFINE`, and link against the static kuzu library in `build/src`, as well as `antlr4_cypher`, `antlr4_runtime`, `brotlidec`, `brotlicommon`, `utf8proc`, `re2`, `serd`, `fastpfor`, `miniparquet`, `zstd`, `miniz`, `mbedtls`, `lz4` (all of which can be found in the third_party subdirectory of the CMake build directory. E.g. `build/third_party/zstd/libzstd.a`) and whichever standard library you're using.

--- a/src/content/docs/client-apis/cpp.mdx
+++ b/src/content/docs/client-apis/cpp.mdx
@@ -260,3 +260,6 @@ conn->createVectorizedFunction("addDate", std::vector<LogicalTypeID>{LogicalType
 // Issue a query using the UDF.
 conn->query("MATCH (p:person) return addDate(p.birthdate, p.age)");
 ```
+## Linking
+
+See the [C API Documentation](/client-apis/c#linking) for details as linking to the C++ API is more or less identical.

--- a/src/content/docs/concurrency.md
+++ b/src/content/docs/concurrency.md
@@ -11,9 +11,10 @@ section below to get answers to common questions.
 In this section, we will go over the basics of how applications connect to a Kùzu database and list some
 best practices on how to do so concurrently.
 
-Kùzu is a disk-based system and each database is stored in a database directory (an in-memory version
-of Kùzu is on our immediate roadmap). Throughout this documentation, let's suppose you have a Kùzu
-database in your local directory `./kuzu-db-dir`.
+When you open Kùzu under on-disk mode, your data and the underlying database files are stored in a
+local database directory. Kùzu also offers an in-memory mode, where no data is persisted to disk.
+Throughout this documentation, let’s suppose you open a Kùzu database that's on-disk, and whose files
+are in a directory named `./kuzu-db-dir`.
 
 ## Understand connections
 

--- a/src/content/docs/get-started/index.mdx
+++ b/src/content/docs/get-started/index.mdx
@@ -638,3 +638,18 @@ The following result is obtained:
 :::tip[Congratulations]
 You've now created and queried your first graph in Kùzu!
 :::
+
+## In-memory Mode
+Kùzu supports both on-disk and in-memory mode.
+
+When the database path is omitted, or specified as empty or `:memory:`, Kùzu will be open under in-memory mode.
+Otherwise, it will be open under on-disk mode.
+
+Under on-disk mode, all data will be persistent on disk. All transactions are logged in WAL, in which changes will be merged into database files during checkpoint.
+While under the in-memory mode, there is no writes to WAL, no data is persistent to disk and `CHECKPOINT` will do nothing. 
+All data are lost when the process finishes.
+
+Compared to on-disk mode, there are several restrictions on the in-memory mode:
+- The database cannot be open as read-only.
+- When use [Httpfs](/extensions/httpfs) extension, we don't support file cache.
+- [Attaching](/extensions/attach) an in-memory database is not allowed.

--- a/src/content/docs/get-started/index.mdx
+++ b/src/content/docs/get-started/index.mdx
@@ -21,9 +21,12 @@ Kùzu implements a _structured_ property graph model and requires a pre-defined 
 ## Quick start
 
 Because Kùzu is an embedded database, there are no servers to set up -- you can simply import
-the `kuzu` module in your preferred client library and begin interacting with the database. Cypher queries
-can be passed as string literals to the `execute` (or equivalent) method in the respective client,
-or run directly in the Kùzu CLI shell.
+the `kuzu` module in your preferred client library and begin interacting with the database by creating
+a Database object in your client API of choice. Cypher queries can be passed as string literals to
+the `execute` (or equivalent) method in the respective client, or run in the Kùzu CLI shell.
+
+The examples below create on-disk databases. Kùzu also supports in-memory mode,
+which is described further [below](#in-memory-mode).
 
 <Tabs>
 <TabItem label="Python">
@@ -165,7 +168,7 @@ f.since: [[2020,2020,2021,2022]]
 const kuzu = require("kuzu");
 
 (async () => {
-  // Create an empty database and connect to it
+  // Create an empty on-disk database and connect to it
   const db = new kuzu.Database("./demo_db");
   const conn = new kuzu.Connection(db);
 
@@ -233,6 +236,7 @@ import com.kuzudb.*;
 public class Main {
 
     public static void main(String[] args) throws KuzuObjectRefDestroyedException {
+        // Create an empty on-disk database
         String db_path = "./testdb";
         KuzuDatabase db = new KuzuDatabase(db_path, 0);
         KuzuConnection conn = new KuzuConnection(db);
@@ -315,7 +319,7 @@ The `main.rs` file contains the following code:
 use kuzu::{Connection, Database, Error, SystemConfig};
 
 fn main() -> Result<(), Error> {
-    // Create an empty database and connect to it
+    // Create an empty on-disk database and connect to it
     let db = Database::new("./demo_db", SystemConfig::default())?;
     let conn = Connection::new(&db)?;
 
@@ -386,7 +390,7 @@ using namespace kuzu::main;
 using namespace std;
 
 int main() {
-    // Create an empty database.
+    // Create an empty on-disk database.
     SystemConfig systemConfig;
     auto database = make_unique<Database>("test", systemConfig);
 
@@ -487,7 +491,7 @@ int main()
 {
     // Create kuzu system config with 512MB buffer pool size and 2 threads.
     kuzu_system_config config = {.buffer_pool_size = 512 * 1024 * 1024, .max_num_threads = 2, .enable_compression = true, .read_only = false};
-    // Create an empty database.
+    // Create an empty on-disk database.
     kuzu_database *db = kuzu_database_init("test", config);
 
     // Connect to the database.
@@ -639,17 +643,23 @@ The following result is obtained:
 You've now created and queried your first graph in Kùzu!
 :::
 
-## In-memory Mode
-Kùzu supports both on-disk and in-memory mode.
+## In-memory mode
 
-When the database path is omitted, or specified as empty or `:memory:`, Kùzu will be open under in-memory mode.
-Otherwise, it will be open under on-disk mode.
+Kùzu supports both on-disk and in-memory modes of operation. When you create a new Database instance
+in your client API of choice, you have two options:
+- If you specify a database path, Kùzu will be opened under **on-disk** mode
+- If you omit the database path, i.e. leave it as empty, or specify it as `:memory:`, Kùzu will be opened under **in-memory** mode
 
-Under on-disk mode, all data will be persistent on disk. All transactions are logged in WAL, in which changes will be merged into database files during checkpoint.
-While under the in-memory mode, there is no writes to WAL, no data is persistent to disk and `CHECKPOINT` will do nothing. 
-All data are lost when the process finishes.
+By default, Kùzu will be opened under on-disk mode, as it's designed to scale to very large graphs.
 
-Compared to on-disk mode, there are several restrictions on the in-memory mode:
-- The database cannot be open as read-only.
-- When use [Httpfs](/extensions/httpfs) extension, we don't support file cache.
-- [Attaching](/extensions/attach) an in-memory database is not allowed.
+:::note[Note]
+- When operating under on-disk mode, all data will be persisted to disk. All transactions are logged
+in the Write-Ahead Log (WAL), in which any changes will be merged into the database files during checkpoints.
+- When operating under in-memory mode, there are **no writes to the WAL**, and no data is persisted to
+disk (so `CHECKPOINT` will do nothing). All data is lost when the process finishes.
+:::
+
+In comparison to on-disk mode, there are a few restrictions when operating under in-memory mode:
+- The database cannot be opened as read-only (only read-write processes are allowed)
+- When using the [httpfs](/extensions/httpfs) extension, we do not support remote file caching
+- [Attaching](/extensions/attach) an in-memory database is not allowed


### PR DESCRIPTION
I've added a few examples and instructions for linking to the C/C++ APIs. The C++ docs just link to the C docs since they are more or less identical in practice.