### PR TITLE
Add LlamaIndex integration example notebook

### DIFF
--- a/src/content/docs/tutorials/index.mdx
+++ b/src/content/docs/tutorials/index.mdx
@@ -54,8 +54,8 @@ ecosystem. Click on the links below to open and run the notebooks.
     href="https://colab.research.google.com/drive/1OxlDLUYZL8jTkqKdVebFtek7yZ5of7FK"
   />
   <LinkCard
-    title="Kùzu and PyTorch Geometric (3)"
-    description="Using Kùzu as a PyTorch Geometric backend"
-    href="https://colab.research.google.com/drive/1OKohp9SlRNe0EO5HrLcNqyqi4XsLFdrV"
+    title="LlamaIndex-Kùzu Integration"
+    description="Using Kùzu as a property graph store for LlamaIndex"
+    href="https://colab.research.google.com/drive/1brAdNRNLG2XHD7Jv3ZwSQCOCJ_wmfd1B"
   />
 </CardGrid>


### PR DESCRIPTION
Add example colab notebook for  Kùzu's integration with LlamaIndex's property graph index.