### PR TITLE
Fixing 2439: Improve Copy Option Usability 

### DIFF
--- a/src/content/docs/export/csv.md
+++ b/src/content/docs/export/csv.md
@@ -27,7 +27,7 @@ Available options are:
 | Option                   | Default Value           | Description                                                               |
 |:------------------------:|:-----------------------:|---------------------------------------------------------------------------|
 | `ESCAPE`                 | `\`                     | Character used to escape special characters in CSV                        |
-| `DELIM`                  | `,`                     | Character that separates fields in the CSV                                |
+| `DELIM` or `DELIMITER`   | `,`                     | Character that separates fields in the CSV                                |
 | `QUOTE`                  | `"`                     | Character used to enclose fields containing special characters or spaces  |
 | `Header`                 | `false`                 | Indicates whether to output a header row                                  |
 

--- a/src/content/docs/import/csv.md
+++ b/src/content/docs/import/csv.md
@@ -10,7 +10,7 @@ The CSV import configuration can be manually set by specifying the parameters in
 end of the the `COPY FROM` clause. The following table shows the configuration parameters supported:
 
 Any option that is a `Boolean` can be enabled or disabled in multiple ways. 
-You can write `true`, `ON`, or `1` to enable the option, and `false`, `OFF`, or `0` to disable it. 
+You can write `true`, `'ON'`, or `1` to enable the option, and `false`, `'OFF'`, or `0` to disable it. 
 The `Boolean` value can also be omitted (e.g., by only passing `(HEADER)`), in which case `true` is assumed.
 
 The assignment operator `=` can also be space ` `.

--- a/src/content/docs/import/csv.md
+++ b/src/content/docs/import/csv.md
@@ -9,9 +9,9 @@ databases. You can use `COPY FROM` to import data into an empty table or to appe
 The CSV import configuration can be manually set by specifying the parameters inside `( )` at the
 end of the the `COPY FROM` clause. The following table shows the configuration parameters supported:
 
-Any option that is a Boolean can be enabled or disabled in multiple ways. 
-You can write true, ON, or 1 to enable the option, and false, OFF, or 0 to disable it. 
-The Boolean value can also be omitted (e.g., by only passing (HEADER)), in which case true is assumed.
+Any option that is a `Boolean` can be enabled or disabled in multiple ways. 
+You can write `true`, `ON`, or `1` to enable the option, and `false`, `OFF`, or `0` to disable it. 
+The `Boolean` value can also be omitted (e.g., by only passing `(HEADER)`), in which case `true` is assumed.
 
 The assignment operator `=` can also be space ` `.
 

--- a/src/content/docs/import/csv.md
+++ b/src/content/docs/import/csv.md
@@ -9,10 +9,16 @@ databases. You can use `COPY FROM` to import data into an empty table or to appe
 The CSV import configuration can be manually set by specifying the parameters inside `( )` at the
 end of the the `COPY FROM` clause. The following table shows the configuration parameters supported:
 
+Any option that is a Boolean can be enabled or disabled in multiple ways. 
+You can write true, ON, or 1 to enable the option, and false, OFF, or 0 to disable it. 
+The Boolean value can also be omitted (e.g., by only passing (HEADER)), in which case true is assumed.
+
+The assignment operator `=` can also be space ` `.
+
 | Parameter | Description | Default Value |
 |:-----|:-----|:-----|
 | `HEADER` | Whether the first line of the CSV file is the header. Can be true or false. | false |
-| `DELIM` | Character that separates different columns in a lines. | `,`|
+| `DELIM` or `DELIMITER` | Character that separates different columns in a lines. | `,`|
 | `QUOTE` | Character to start a string quote. | `"` |
 | `ESCAPE` | Character within string quotes to escape QUOTE and other characters, e.g., a line break. <br/> See the important note below about line breaks lines below.| `\` |
 | `SKIP` | Number of rows to skip from the input file | `0` |


### PR DESCRIPTION
# Description

This a related doc PR to the PR in main repository: [Fixing 2439: Improve Copy Option Usability] (https://github.com/kuzudb/kuzu/pull/4230) which fixed issue[2439](https://github.com/kuzudb/kuzu/issues/2439#issuecomment-2338483499).

This Docs updates added the illustration to the new grammar for copy option.

We now support multiple ways of expressing Boolean value (`0/1; on/off; true/false`), and also support both empty space and equation sign for assignment operator.

We also support omitted boolean option value, which would be set to `true` as default.

Both name of `DELIM` and `DELIMITER` can be used, to be compatible with DUCKDB.

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).