### PR TITLE
Update docs for copy warnings

### DIFF
--- a/src/content/docs/cypher/query-clauses/call.md
+++ b/src/content/docs/cypher/query-clauses/call.md
@@ -177,7 +177,7 @@ Output:
 
 ### SHOW_WARNINGS
 
-`SHOW_WARNINGS` returns the warnings encountered during the current connection when loading from files. They will only be reported if the [`IGNORE_ERRORS`](/import/csv#ignoring-erroneous-rows) setting is enabled. The number of warnings that can be stored per connection is limited; any warnings encountered after the warning limit is hit will not be stored. See [configuration](/cypher/configuration#configure-warning-limit) for more details on the warning limit.
+`SHOW_WARNINGS` returns the warnings encountered during the current connection when loading from files. They will only be reported if the [`IGNORE_ERRORS`](/import/csv#ignoring-erroneous-rows) setting is enabled. The number of warnings that can be stored per connection is limited; after the warning limit is hit, any warnings encountered will not be stored. See [configuration](/cypher/configuration#configure-warning-limit) for more details on how to set the warning limit.
 
 | Column | Description | Type |
 | ------ | ----------- | ---- |
@@ -202,21 +202,8 @@ Output:
 
 ### CLEAR_WARNINGS
 
-Over the lifetime of a connection, warnings accumulate in the warning table (which can be queried with [`SHOW_WARNINGS`](#show_warnings)). If you are no longer interested in the accumulated warnings, the table can be cleared with `CLEAR_WARNINGS`.
-
-| Column | Description | Type |
-| ------ | ----------- | ---- |
-| status | 0 if the warning table was cleared successfully | UINT8 |
+Over the lifetime of a connection, warnings accumulate in the warning table (which can be queried with [`SHOW_WARNINGS`](#show_warnings)). If you are no longer interested in the accumulated warnings, the table can be cleared with `CLEAR_WARNINGS`. This function has no output.
 
 ```cypher
-CALL clear_warnings() RETURN *;
-```
-Output:
-```
-┌────────┐
-│ status │
-│ UINT8  │
-├────────┤
-│ 0      │
-└────────┘
+CALL clear_warnings();
 ```

--- a/src/content/docs/import/copy-from-json.md
+++ b/src/content/docs/import/copy-from-json.md
@@ -45,7 +45,7 @@ COPY Person FROM 'people.json';
 
 See the [`JSON`](/extensions/json) extension documentation for more related features on working with JSON files.
 
-### Ignoring Erroneous Rows
+## Ignoring Erroneous Rows
 
 By specifying the `ignore_errors` option to `true`, we can ignore erroneous rows in JSON files. Consider the following example:
 

--- a/src/content/docs/import/csv.md
+++ b/src/content/docs/import/csv.md
@@ -16,8 +16,8 @@ end of the the `COPY FROM` clause. The following table shows the configuration p
 | `QUOTE` | Character to start a string quote. | `"` |
 | `ESCAPE` | Character within string quotes to escape QUOTE and other characters, e.g., a line break. <br/> See the important note below about line breaks lines below.| `\` |
 | `SKIP` | Number of rows to skip from the input file | `0` |
-| `PARALLEL` | Read csv files in parallel or not | `true` |
-| `IGNORE_ERRORS` | Skips malformed rows in csv files if enabled. [The `SHOW_WARNINGS` function](/cypher/query-clauses/call#show_warnings) can be used to view the warning messages triggered by the malformed rows. | `false` |
+| `PARALLEL` | Read CSV files in parallel or not | `true` |
+| `IGNORE_ERRORS` | Skips malformed rows in CSV files if enabled. [The `SHOW_WARNINGS` function](/cypher/query-clauses/call#show_warnings) can be used to view the warning messages triggered by the malformed rows. | `false` |
 
 The example below specifies that the CSV delimiter is`|` and also that the header row exists.
 
@@ -94,17 +94,7 @@ Output:
 Once we are done inspecting the warnings, we can call [`clear_warnings`](/cypher/query-clauses/call#clear_warnings) to clear the warning table.
 
 ```cypher
-CALL clear_warnings() RETURN *;
-```
-
-Output:
-```
-┌────────┐
-│ status │
-│ UINT8  │
-├────────┤
-│ 0      │
-└────────┘
+CALL clear_warnings();
 ```
 
 After clearing the warnings, the warning table will be empty.


### PR DESCRIPTION
`clear_warnings()` now returns nothing, update the docs to reflect that. Also make some minor rewording/clarification to the docs.