### PR TITLE
Add elixir community client package

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -149,6 +149,7 @@ export default defineConfig({
                         { label: 'C++', link: '/client-apis/cpp' },
                         { label: 'C', link: '/client-apis/c' },
                         { label: '.NET', link: '/client-apis/net', badge: { text: 'Community', variant: 'caution'}},
+                        { label: 'Elixir', link: '/client-apis/elixir', badge: { text: 'Community', variant: 'caution'}}
                     ],
                 },
                 { label: 'Connections & concurrency', link: '/concurrency' },

--- a/src/content/docs/client-apis/elixir.mdx
+++ b/src/content/docs/client-apis/elixir.mdx
@@ -4,9 +4,10 @@ title: Kùzu NIF for Elixir
 
 import { LinkCard } from '@astrojs/starlight/components';
 
-Elixir is a programming language based on the BEAM virtual environment that's a common choice among developers for building full-stack applications.
-It has specific features for this such as a functional style, strong community, Erlang compatibility, and a lot of concurrency-friendly
-features like preemptive scheduling and spawning a large number of process without incurring a large overhead.
+Elixir is a programming language based on the BEAM virtual environment.
+Its functional style, strong community, Erlang compatibility and concurrency-friendly
+features, like preemptive scheduling and spawning a large number of process without incurring much overhead,
+make it a popular choice among developers for building full-stack applications.
 
 <LinkCard
   title="Kùzu NIF for Elixir"

--- a/src/content/docs/client-apis/elixir.mdx
+++ b/src/content/docs/client-apis/elixir.mdx
@@ -1,0 +1,24 @@
+---
+title: Kùzu NIF for Elixir
+---
+
+import { LinkCard } from '@astrojs/starlight/components';
+
+Elixir is a programming language based on the BEAM virtual environment that's a common choice among developers for building full-stack applications.
+It has specific features for this such as a functional style, strong community, Erlang compatibility, and a lot of concurrency-friendly
+features like preemptive scheduling and spawning a large number of process without incurring a large overhead.
+
+<LinkCard
+  title="Kùzu NIF for Elixir"
+  description="The NIF package is maintained as an independent, external open source project."
+  href="https://hex.pm/packages/kuzu_nif"
+/>
+
+In Elixir, a NIF (Native Implemented Function) is a function written in a native language (in this case, Rust)
+that can be called directly from Elixir code, allowing developers to leverage high-performance, low-level
+operations within their Elixir applications, essentially providing a way to extend the functionality of the
+Erlang BEAM virtual machine by executing code outside of its standard runtime environment.
+
+If you build applications in Elixir, you can access the NIF package using the instructions shown
+[here](https://github.com/bgoosmanviz/kuzu_nif), based on the NIF package that adapts Kùzu's officially
+supported Rust crate to Elixir.

--- a/src/content/docs/client-apis/index.mdx
+++ b/src/content/docs/client-apis/index.mdx
@@ -59,4 +59,9 @@ unsupported. The following client libraries have been contributed by the communi
     title=".NET"
     href="/client-apis/net"
   />
+
+  <LinkCard
+    title="Elixir"
+    href="/client-apis/elixir"
+  />
 </CardGrid>


### PR DESCRIPTION
Adding the Kùzu Elixir NIF (external contributor) package that allows Elixir users to build on top of Kùzu, to the docs.