### PR TITLE
Update ignore errors docs as it now works on pandas/pyarrow

### DIFF
--- a/src/content/docs/import/copy-from-dataframe.md
+++ b/src/content/docs/import/copy-from-dataframe.md
@@ -33,7 +33,7 @@ conn.execute("COPY Person FROM df")
 
 ## Polars
 
-You can utilize an existing Polars DataFrame to copy data directly into Kùzu. 
+You can utilize an existing Polars DataFrame to copy data directly into Kùzu.
 
 ```python
 import kuzu
@@ -73,3 +73,7 @@ pa_table = pa.table({
 
 conn.execute("COPY Person FROM pa_table")
 ```
+
+## Ignore erroneous rows
+
+See the [Ignore erroneous rows](/import#ignore-erroneous-rows) section for more details.

--- a/src/content/docs/import/index.mdx
+++ b/src/content/docs/import/index.mdx
@@ -202,12 +202,12 @@ CALL warning_limit=1024;
 ```
 ### Skippable Errors By Source
 
-Currently `IGNORE_ERRORS` option works when scanning files (and not in-memory data frames or when running
-`COPY/LOAD FROM` on sub-queries). For different files, the errors that can be skipped can be different.
-If the error is not skippable in a file format, `COPY/LOAD FROM` will instead error and fail.
+Currently `IGNORE_ERRORS` option works when scanning files or in-memory data frames (but not when running
+`COPY/LOAD FROM` on sub-queries). For different sources, the errors that can be skipped can be different.
+If the error is not skippable for a specific source, `COPY/LOAD FROM` will instead error and fail.
 Below is a table that shows the errors that are skippable by each source.
 
 ||Parsing Errors|Casting Errors|Duplicate/Null/Missing Primary-Key errors|
 |----|----|----|----|
 |CSV| X | X | X |
-|JSON/Numpy/Parquet|||X|
+|JSON/Numpy/Parquet/PyArrow/Pandas Dataframes|||X|

--- a/src/content/docs/import/index.mdx
+++ b/src/content/docs/import/index.mdx
@@ -210,4 +210,4 @@ Below is a table that shows the errors that are skippable by each source.
 ||Parsing Errors|Casting Errors|Duplicate/Null/Missing Primary-Key errors|
 |----|----|----|----|
 |CSV| X | X | X |
-|JSON/Numpy/Parquet/PyArrow/Pandas Dataframes|||X|
+|JSON/Numpy/Parquet/PyArrow/Pandas/Polars Dataframes|||X|


### PR DESCRIPTION
https://github.com/kuzudb/kuzu/pull/4646 added support for `IGNORE_ERRORS` on pandas/pyarrow/polars, I updated the docs to include this.