### PR TITLE
Update docs for `clear_db_cache` function

### DIFF
--- a/src/content/docs/extensions/attach/rdbms.mdx
+++ b/src/content/docs/extensions/attach/rdbms.mdx
@@ -219,7 +219,7 @@ schema data may become obsolete. You can use the `clear_attached_db_cache()` fun
 schema information in such cases.
 
 ```sql
-CALL clear_attached_db_cache() RETURN *
+CALL clear_attached_db_cache()
 ```
 Note: If you have attached to databases from different
 RDBMSs, say Postgres, DuckDB, and Sqlite, this call will clear the cache for all of them.
@@ -426,7 +426,7 @@ schema data may become obsolete. You can use the `clear_attached_db_cache()` fun
 schema information in such cases.
 
 ```sql
-CALL clear_attached_db_cache() RETURN *
+CALL clear_attached_db_cache()
 ```
 Note: If you have attached to databases from different
 RDBMSs, say Postgres, DuckDB, and Sqlite, this call will clear the cache for all of them.
@@ -596,7 +596,7 @@ schema data may become obsolete. You can use the `clear_attached_db_cache()` fun
 schema information in such cases.
 
 ```sql
-CALL clear_attached_db_cache() RETURN *
+CALL clear_attached_db_cache()
 ```
 Note: If you have attached to databases from different
 RDBMSs, say Postgres, DuckDB, and Sqlite, this call will clear the cache for all of them.


### PR DESCRIPTION
We changed `clear_db_cache` function to standalone call function which doesn't need a return statement after it: https://github.com/kuzudb/kuzu/pull/4835
This PR updates the doc for it.