### PR TITLE
Fix fts doc

### DIFF
--- a/src/content/docs/extensions/full-text-search.md
+++ b/src/content/docs/extensions/full-text-search.md
@@ -20,15 +20,15 @@ LOAD EXTENSION FTS;
 ### Example dataset
 
 Let's look at an example dataset to demonstrate how the FTS extension can be used.
-First, let's create a `Book` table containing each book's information, including the title, author and abstract.
+First, let's create a `Book` table containing each book's information, including the title and abstract.
 
 ```cypher
-CREATE NODE TABLE Book (ID SERIAL, abstract STRING, author STRING, title STRING, PRIMARY KEY (ID));
-CREATE (b:Book {abstract: 'An exploration of quantum mechanics.', author: 'Alice Johnson', title: 'The Quantum World'});
-CREATE (b:Book {abstract: 'A magic journey through time and space.', author: 'John Smith', title: 'Chronicles of the Universe'});
-CREATE (b:Book {abstract: 'An introduction to machine learning techniques.', author: 'Emma Brown', title: 'Learning Machines'});
-CREATE (b:Book {abstract: 'A deep dive into the history of ancient civilizations.', author: 'Michael Lee', title: 'Echoes of the Past'});
-CREATE (b:Book {abstract: 'A fantasy tale of dragons and magic.', author: 'Charlotte Harris', title: 'The Dragon\'s Call'});
+CREATE NODE TABLE Book (ID SERIAL, abstract STRING, title STRING, PRIMARY KEY (ID));
+CREATE (b:Book {abstract: 'An exploration of quantum mechanics.', title: 'The Quantum World'});
+CREATE (b:Book {abstract: 'A magic journey through time and space.', title: 'Chronicles of the Universe'});
+CREATE (b:Book {abstract: 'An introduction to machine learning techniques.', title: 'Learning Machines'});
+CREATE (b:Book {abstract: 'A deep dive into the history of ancient civilizations.', title: 'Echoes of the Past'});
+CREATE (b:Book {abstract: 'A fantasy tale of dragons and magic.', title: 'The Dragon\'s Call'});
 ```
 
 In the following sections, we will build a full-text search index on the book table, and demonstrate how to search for books relevant to a keyword query.
@@ -40,7 +40,7 @@ Kùzu provides a function `CREATE_FTS_INDEX` to create the full-text search inde
 ```cypher
 CALL CREATE_FTS_INDEX('TABLE_NAME', 'INDEX_NAME', ['PROP1', 'PROP2', 'PROP3'...], OPTIONAL_PARAM1 := 'OPTIONAL_VAL1')
 ```
-- `TABLE_NAME`: The name of the table to build FTS index.
+- `TABLE_NAME`: The name of the node table to build FTS index.
 - `INDEX_NAME`: The name of the FTS index to create.
 - `PROPERTIES`: A list of properties in the table to build FTS index on. Full text search will only search the properties with FTS index built on.
 
@@ -49,18 +49,19 @@ The following optional parameters are supported:
 - `stemmer`: The text normalization technique to use. Should be one of: `arabic`, `basque`, `catalan`, `danish`, `dutch`, `english`, `finnish`, `french`, `german`, `greek`, `hindi`, `hungarian`, `indonesian`, `irish`, `italian`, `lithuanian`, `nepali`, `norwegian`, `porter`, `portuguese`, `romanian`, `russian`, `serbian`, `spanish`, `swedish`, `tamil`, `turkish`, or `none` if no stemming is to be used. Defaults to `english`,
 which uses a Snowball stemmer.
 
-The example below shows how to create an FTS index on the book table with the `abstract`, `author` and `title` properties using the `porter` stemmer.
+The example below shows how to create an FTS index on the book table with the `abstract` and `title` properties using the `porter` stemmer.
 
 :::caution[Note]
-Kùzu uses special syntax for optional parameters. Note how the `:=` operator is used to assign a value
+1. Kùzu uses special syntax for optional parameters. Note how the `:=` operator is used to assign a value
 to an optional parameter in the example below.
+2. Users can only build full text search indexes on node tables.
 :::
 
 ```cypher
 CALL CREATE_FTS_INDEX(
     'Book',   // Table name
     'book_index',   // Index name
-    ['abstract', 'author', 'title'],   // Properties to build FTS index on
+    ['abstract', 'title'],   // Properties to build FTS index on
     stemmer := 'porter'   // Stemmer to use (optional)
 )
 ```
@@ -79,6 +80,7 @@ CALL QUERY_FTS_INDEX(
     'QUERY',
     OPTIONAL_PARAM1 := 'OPTIONAL_VAL1'...
 )
+RETURN node, score
 ```
 - `TABLE_NAME`: The name of the table to query
 - `INDEX_NAME`: The name of the FTS index to query
@@ -95,49 +97,49 @@ Detailed explanation of k and b values can be found [there](https://learn.micros
 The below example shows how to query books related to the `quantum machine` and order the books by their scores:
 ```cypher
 CALL QUERY_FTS_INDEX('Book', 'book_index', 'quantum machine')
-RETURN node.title, score
+RETURN node.title as title, node.abstract as abstract, score
 ORDER BY score DESC;
 ```
 
 Result:
 ```
-┌───────────────────┬──────────┐
-│ node.title        │ score    │
-│ STRING            │ DOUBLE   │
-├───────────────────┼──────────┤
-│ The Quantum World │ 0.857996 │
-│ Learning Machines │ 0.827832 │
-└───────────────────┴──────────┘
+┌───────────────────┬─────────────────────────────────────────────────┬──────────┐
+│ title             │ abstract                                        │ score    │
+│ STRING            │ STRING                                          │ DOUBLE   │
+├───────────────────┼─────────────────────────────────────────────────┼──────────┤
+│ The Quantum World │ An exploration of quantum mechanics.            │ 0.868546 │
+│ Learning Machines │ An introduction to machine learning techniques. │ 0.827832 │
+└───────────────────┴─────────────────────────────────────────────────┴──────────┘
 ```
 
 The `conjunctive` option can be used when you want to retrieve only the books containing _all_ the keywords in the query.
 ```cypher
 CALL QUERY_FTS_INDEX('Book', 'book_index', 'dragon magic', conjunctive := true)
-RETURN node.title, score
+RETURN node.title as title, node.abstract as abstract, score
 ORDER BY score DESC;
 ```
 
 Result:
 ```
-┌───────────────────┬──────────┐
-│ node.title        │ score    │
-│ STRING            │ DOUBLE   │
-├───────────────────┼──────────┤
-│ The Dragon's Call │ 1.208044 │
-└───────────────────┴──────────┘
+┌───────────────────┬──────────────────────────────────────┬──────────┐
+│ title             │ abstract                             │ score    │
+│ STRING            │ STRING                               │ DOUBLE   │
+├───────────────────┼──────────────────────────────────────┼──────────┤
+│ The Dragon's Call │ A fantasy tale of dragons and magic. │ 1.208044 │
+└───────────────────┴──────────────────────────────────────┴──────────┘
 ```
 
 If you want to retrieve books with either the `dragon` OR `magic` keywords, set `conjunctive` to `false`
 ```cypher
 CALL QUERY_FTS_INDEX('Book', 'book_index', 'dragon magic', conjunctive := false)
-RETURN node.title, score
+RETURN node.title as title, score
 ORDER BY score DESC;
 ```
 
 Result:
 ```
 ┌────────────────────────────┬──────────┐
-│ node.title                 │ score    │
+│ title                      │ score    │
 │ STRING                     │ DOUBLE   │
 ├────────────────────────────┼──────────┤
 │ The Dragon's Call          │ 1.208044 │
@@ -171,12 +173,12 @@ This will return a list of all the indexes available in the database, while also
 index. Scan the table to find the FTS indexes that are currently available.
 
 ```
-┌────────────┬─────────────┬────────────┬─────────────────────────┬──────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ table name │ index nam   │ index type │ property names          │ extension loaded │ index definition                                                                                    │
-│ STRING     │ STRING      │ STRING     │ STRING[]                │ BOOL             │ STRING                                                                                              │
-├────────────┼─────────────┼────────────┼─────────────────────────┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ book       │ book_index  │ FTS        │ [abstract,author,title] │ True             │ CALL CREATE_FTS_INDEX('book', 'book_index', ['abstract', 'author', 'title' ], stemmer := 'porter'); │
-└────────────┴─────────────┴────────────┴─────────────────────────┴──────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌────────────┬────────────┬────────────┬──────────────────┬──────────────────┬──────────────────────────────────────────────────────────────────────────────────────────┐
+│ table name │ index name │ index type │ property names   │ extension loaded │ index definition                                                                         │
+│ STRING     │ STRING     │ STRING     │ STRING[]         │ BOOL             │ STRING                                                                                   │
+├────────────┼────────────┼────────────┼──────────────────┼──────────────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
+│ Book       │ book_index │ FTS        │ [abstract,title] │ True             │ CALL CREATE_FTS_INDEX('Book', 'book_index', ['abstract', 'title'], stemmer := 'porter'); │
+└────────────┴────────────┴────────────┴──────────────────┴──────────────────┴──────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ### Prepared statement


### PR DESCRIPTION
fix fts document example from semih's comment
1. Removes the author column to give a minimum example.
2. Returns the abstract field in the query.
3. Add note for fts can only be built on node tables.