### PR TITLE
Update Kùzu to Kuzu across docs

### DIFF
--- a/src/content/docs/cypher/query-clauses/call.md
+++ b/src/content/docs/cypher/query-clauses/call.md
@@ -237,7 +237,7 @@ If you would like to know information about loaded extensions in Kùzu, you can 
 | Column | Description | Type |
 | ------ | ----------- | ---- |
 | extension name | name of the extension | STRING |
-| extension source | whether the extension is officially supported by Kùzu Inc., or developed by a third-party | STRING |
+| extension source | whether the extension is officially supported by the Kuzu team or is developed by a third-party | STRING |
 | extension path | the path to the extension | STRING |
 
 ```cypher

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -32,7 +32,7 @@ introductory video. Once you're ready to dive in, check out the rest of the docu
   </iframe>
 </div>
 
-## Why Kùzu
+## Why Kùzu?
 
 Although there are many graph database management systems (GDBMSs) in the market today,
 Kùzu stands apart because it addresses specific trade-offs via its design and implementation that
@@ -41,10 +41,10 @@ Below, we list some of the key reasons why you may want to consider using Kùzu.
 
 ### Performance and scalability
 
-Kùzu is a state-of-the-art graph DBMS and is built by a core team of database experts who spent many years
-doing academic research. Its design and implementation are based on a relentless focus towards
-scalability and performance, with the founding engineers having co-authored several cutting-edge
-technical papers and articles on managing and querying large-scale graphs.
+Kùzu is a state-of-the-art graph DBMS that came out of modern academic research, and is built by a
+core team of database experts who possess a relentless drive towards scalability and performance.
+Its founding engineers have co-authored several cutting-edge technical papers and articles on managing
+and querying large graphs.
 
 ### Usability
 


### PR DESCRIPTION
Based on an internal discussion, we will be referencing the database name as Kuzu in our docs for ease of communication and discoverability by search engines. The company name is still, officially, Kùzu Inc.