### PR TITLE
Improve links

### DIFF
--- a/src/content/docs/extensions/index.mdx
+++ b/src/content/docs/extensions/index.mdx
@@ -32,12 +32,12 @@ The following extensions are implemented, with more to come:
 | Extension Name | Description |
 |----------|----------|
 | [httpfs](/extensions/httpfs) | Read and write files over HTTP(s) protocol. Also used for [attaching to a remote Kùzu database](/extensions/attach/kuzu). |
-| [duckdb](/extensions/attach) | Scan data from an attached DuckDB database |
-| [postgres](/extensions/attach) | Scan data from an attached PostgreSQL database |
-| [sqlite](/extensions/attach) | Scan data from an attached SQLite database |
-| [json](/extensions/json) | Scan and manipulate JSON data |
+| [duckdb](/extensions/attach/rdbms) | Scan data from an attached DuckDB database |
+| [postgres](/extensions/attach/rdbms) | Scan data from an attached PostgreSQL database |
+| [sqlite](/extensions/attach/rdbms) | Scan data from an attached SQLite database |
 | [delta](/extensions/delta) | Scan data from a delta table |
 | [iceberg](/extensions/iceberg) | Scan iceberg data |
+| [json](/extensions/json) | Scan and manipulate JSON data |
 
 ## Using Extensions in Kùzu
 

--- a/src/content/docs/extensions/index.mdx
+++ b/src/content/docs/extensions/index.mdx
@@ -35,9 +35,9 @@ The following extensions are implemented, with more to come:
 | [duckdb](/extensions/attach/rdbms) | Scan data from an attached DuckDB database |
 | [postgres](/extensions/attach/rdbms) | Scan data from an attached PostgreSQL database |
 | [sqlite](/extensions/attach/rdbms) | Scan data from an attached SQLite database |
+| [json](/extensions/json) | Scan and manipulate JSON data |
 | [delta](/extensions/delta) | Scan data from a delta table |
 | [iceberg](/extensions/iceberg) | Scan iceberg data |
-| [json](/extensions/json) | Scan and manipulate JSON data |
 
 ## Using Extensions in Kùzu
 


### PR DESCRIPTION
How about directly linking to the subpage?

Aside: perhaps https://docs.kuzudb.com/extensions/attach/kuzu/ should actually be inside httpfs: https://docs.kuzudb.com/extensions/httpfs/kuzu/ ?