### PR TITLE
Update docs for array functions + ignore errors

### DIFF
--- a/src/content/docs/cypher/expressions/array-functions.md
+++ b/src/content/docs/cypher/expressions/array-functions.md
@@ -16,9 +16,11 @@ Scroll to the right to see the example usage in the below table.
 | Function | Description | Example | Result |
 | ----------- | --------------- | ----------- | ----------- |
 | `array_value(arg1, arg2, arg3..)` | creates an array containing the argument values | `array_value(1,2,3,4,5,56,2)` | `[1,2,3,4,5,56,2]` |
-| `array_dot_product(array1, array2)` | calculates the dot product of two arrays | `array_dot_product([1,2,3], [4,5,6])` | `32` |
-| `array_inner_product(array1, array2)` | calculates the inner product of two arrays | `array_inner_product([1,2,3], [4,5,6])` | `32` |
-| `array_cross_product(array1, array2)` | calculates the cross product of two arrays | `array_cross_product([1,2,3], [4,5,6])` | `[[-3,6,-3],[6,-12,6],[-3,6,-3]]` |
-| `array_cosine_similarity(array1, array2)` | calculates the cosine similarity of two arrays | `array_cosine_similarity([1,2,3], [4,5,6])` | `0.9746318461970762` |
+| `array_distance(array1, array2)` | calculates the euclidean distance between two arrays | `array_distance([1.0,2.0,3.0], [4.0,5.0,6.0])` | `5.196152` |
+| `array_squared_distance(array1, array2)` | calculates the squared euclidean distance between two arrays | `array_squared_distance([1.0,2.0,3.0], [4.0,5.0,6.0])` | `27.000000` |
+| `array_dot_product(array1, array2)` | calculates the dot product of two arrays | `array_dot_product([1.0,2.0,3.0], [4.0,5.0,6.0])` | `32.000000` |
+| `array_inner_product(array1, array2)` | calculates the inner product of two arrays | `array_inner_product([1.0,2.0,3.0], [4.0,5.0,6.0])` | `32.000000` |
+| `array_cross_product(array1, array2)` | calculates the cross product of two arrays | `array_cross_product([1,2,3], [4,5,6])` | `[-3,6,-3]` |
+| `array_cosine_similarity(array1, array2)` | calculates the cosine similarity of two arrays | `array_cosine_similarity([1.0,2.0,3.0], [4.0,5.0,6.0])` | `0.974632` |
 
 </div>

--- a/src/content/docs/import/index.mdx
+++ b/src/content/docs/import/index.mdx
@@ -211,8 +211,7 @@ CALL warning_limit=1024;
 ```
 ### Skippable Errors By Source
 
-Currently `IGNORE_ERRORS` option works when scanning files or in-memory data frames (but not when running
-`COPY/LOAD FROM` on sub-queries). For different sources, the errors that can be skipped can be different.
+When the `IGNORE_ERRORS` option is enabled, the errors that can be skipped can be different depending on the scan source.
 If the error is not skippable for a specific source, `COPY/LOAD FROM` will instead error and fail.
 Below is a table that shows the errors that are skippable by each source.
 
@@ -225,5 +224,4 @@ Below is a table that shows the errors that are skippable by each source.
 |PyArrow tables| ❌ | ❌ | ✅ |
 |Pandas DataFrames| ❌ | ❌ | ✅ |
 |Polars DataFrames| ❌ | ❌ | ✅ |
-
-
+|Subquery| ❌ | ❌ | ✅ |


### PR DESCRIPTION
- `IGNORE_ERRORS` when copying from subquery is now supported, update docs to reflect that
- Update array functions docs:
  - We now support `array_squared_distance()`, document that as well as `array_distance()` which wasn't documented before
  - Update examples so that they are valid queries (many of the array function only work on FLOAT/DOUBLE inputs)
  - Update example outputs so that they match the output of the query in shell