### PR TITLE
Fix codeblocks in return.md

### DIFF
--- a/src/content/docs/cypher/query-clauses/return.md
+++ b/src/content/docs/cypher/query-clauses/return.md
@@ -114,7 +114,7 @@ Output:
 You can use RETURN DISTINCT to do duplicate elimination of the returned tuples.
 For example, if we instead wrote `RETURN DISTINCT` in the above query, we would
 eliminate one of the 2 (Adam, 30, 2020) tuples above:
-```
+```cypher
 MATCH (a:User)-[e:Follows]->(b:User)
 RETURN DISTINCT a.name, a.age, e.since;
 ```

--- a/src/content/docs/cypher/query-clauses/return.md
+++ b/src/content/docs/cypher/query-clauses/return.md
@@ -94,6 +94,7 @@ Output:
 -------------------
 | Noura   | 25    |
 -------------------
+```
 
 ```cypher
 MATCH (a:User)-[e:Follows]->(b:User) WHERE a.name='Adam' RETURN e.*;


### PR DESCRIPTION
Hi,

Here is a small PR to correct the missing backticks and language in the "Returning node and relationship properties" paragraph on the [Return query clause page](https://docs.kuzudb.com/cypher/query-clauses/return/)