### PR TITLE
Fix fts doc example

### DIFF
--- a/src/content/docs/extensions/full-text-search.md
+++ b/src/content/docs/extensions/full-text-search.md
@@ -47,9 +47,9 @@ The following optional parameters are supported:
 
 - `stemmer`: The text normalization technique to use. Should be one of: `arabic`, `basque`, `catalan`, `danish`, `dutch`, `english`, `finnish`, `french`, `german`, `greek`, `hindi`, `hungarian`, `indonesian`, `irish`, `italian`, `lithuanian`, `nepali`, `norwegian`, `porter`, `portuguese`, `romanian`, `russian`, `serbian`, `spanish`, `swedish`, `tamil`, `turkish`, or `none` if no stemming is to be used. Defaults to `english`,
 which uses a Snowball stemmer.
-- `stopwords`: To make the full-text search results more useful, it's useful to provide a list of omitted words that are excluded when building and querying the full-text search index. These are termed "stopwords". A default list of built-in english stopwords is used, but these can be customized by using the `stopwords` parameter. Kuzu accepts stopwords in the following formats:
-1. A node table with only a single column of stopwords.
-2. A PARQUET/CSV file with only a single string column of stopwords(no header required). This file can be stored in cloud storage platforms like Amazon S3 or Google Cloud Storage (GCS) or made accessible via HTTPS. If hosted remotely, ensure the httpfs extension is enabled and valid credentials (e.g., access keys) are configured to authenticate and securely access the file.
+- `stopwords`: To make the full-text search results more useful, it's useful to provide a list of omitted words that are excluded when building and querying the full-text search index. These are termed "stopwords". A default list of built-in english stopwords is used, but if you want to use a custom stopwords list, you can provide it via the `stopwords` parameter in the following formats:
+  - A node table with only a single column of stopwords.
+  - A Parquet/CSV file with only a single string column of stopwords (no header required). This file can be stored in cloud storage platforms like Amazon S3 or Google Cloud Storage (GCS) or made accessible via HTTPS. If hosted remotely, ensure the httpfs extension is enabled and valid credentials (e.g., access keys) are configured to authenticate and securely access the file.
 
 :::caution[Note]
 1. If the provided stopwords parameter matches both a node table and a file with the same name, the node table takes precedence and will be used.
@@ -77,7 +77,8 @@ CALL CREATE_FTS_INDEX(
     'Book',   // Table name
     'book_index',   // Index name
     ['abstract', 'title'],   // Properties to build FTS index on
-    stemmer := 'porter'   // Stemmer to use (optional)
+    stemmer := 'porter',   // Stemmer to use (optional)
+    stopwords := './stopwords.csv'   // Custom stopwords list via file or https URL, (optional)
 );
 ```
 Once the index is created, the index will be ready for querying as shown below.

--- a/src/content/docs/extensions/full-text-search.md
+++ b/src/content/docs/extensions/full-text-search.md
@@ -77,8 +77,7 @@ CALL CREATE_FTS_INDEX(
     'Book',   // Table name
     'book_index',   // Index name
     ['abstract', 'title'],   // Properties to build FTS index on
-    stemmer := 'porter',   // Stemmer to use (optional)
-    stopwords := 'https://stopwords/porter.txt' // Configure customized stopwords list
+    stemmer := 'porter'   // Stemmer to use (optional)
 );
 ```
 Once the index is created, the index will be ready for querying as shown below.


### PR DESCRIPTION
The fts doc example in the doc page doesn't work in kuzu because it requires users host the `porter.txt` file on a webserver and install the httpfs extension.

If we want to keep the example of using `stopwords` parameter,  we have to host the `porter.txt` file on our webserver and let the user install `httpfs` extension beforehand.

I suggest removing the `stopwords` example to make things simpler.

@ray6080 What do you think of this?