### PR TITLE
Add copy into rel table with multiple from-to pairs to data import se…

### DIFF
--- a/src/content/docs/import/copy-from-json.md
+++ b/src/content/docs/import/copy-from-json.md
@@ -138,6 +138,16 @@ COPY HAS_CONDITION FROM 'has_condition.json'
 
 See the [`JSON`](/extensions/json) extension documentation for more related features on working with JSON files.
 
+### Relationship table with multiple `FROM-TO` pairs
+
+If a relationship table has multiple `FROM-TO` pairs, you need to specify which pair to insert through `from, to` options. For example
+
+```sql
+Copy Knows FROM 'knows_user_user.json' (from='User', to='User');
+```
+
+More information can be found [here](/cypher/data-definition/create-table).
+
 ## Ignoring erroneous rows
 
 Like for CSV files, Kuzu can skip rows when some types of errors are encountered when importing from JSON.

--- a/src/content/docs/import/copy-from-json.md
+++ b/src/content/docs/import/copy-from-json.md
@@ -140,10 +140,10 @@ See the [`JSON`](/extensions/json) extension documentation for more related feat
 
 ### Relationship table with multiple `FROM-TO` pairs
 
-If a relationship table has multiple `FROM-TO` pairs, you need to specify which pair to insert through `from, to` options. For example
+If a relationship table has multiple `FROM-TO` pairs, you need to specify which pair to insert by specifying `from` and `to` parameters. For example:
 
 ```sql
-Copy Knows FROM 'knows_user_user.json' (from='User', to='User');
+COPY Knows FROM 'knows_user_user.json' (from='User', to='User');
 ```
 
 More information can be found [here](/cypher/data-definition/create-table).

--- a/src/content/docs/import/csv.md
+++ b/src/content/docs/import/csv.md
@@ -77,6 +77,16 @@ To skip the first 3 lines of the CSV file, you can use the `SKIP` parameter as f
 COPY Follows FROM "follows.csv" (SKIP=3);
 ```
 
+### Relationship table with multiple `FROM-TO` pairs
+
+If a relationship table has multiple `FROM-TO` pairs, you need to specify which pair to insert through `from, to` options. For example
+
+```sql
+Copy Knows FROM 'knows_user_user.csv' (from='User', to='User');
+```
+
+More information can be found [here](/cypher/data-definition/create-table)
+
 ## Import multiple files to a single table
 
 It is common practice to divide a large CSV file into several smaller files for cleaner data management.

--- a/src/content/docs/import/csv.md
+++ b/src/content/docs/import/csv.md
@@ -79,10 +79,10 @@ COPY Follows FROM "follows.csv" (SKIP=3);
 
 ### Relationship table with multiple `FROM-TO` pairs
 
-If a relationship table has multiple `FROM-TO` pairs, you need to specify which pair to insert through `from, to` options. For example
+If a relationship table has multiple `FROM-TO` pairs, you need to specify which pair to insert by specifying `from` and `to` parameters. For example:
 
 ```sql
-Copy Knows FROM 'knows_user_user.csv' (from='User', to='User');
+COPY Knows FROM 'knows_user_user.csv' (from='User', to='User');
 ```
 
 More information can be found [here](/cypher/data-definition/create-table)

--- a/src/content/docs/import/parquet.md
+++ b/src/content/docs/import/parquet.md
@@ -62,10 +62,10 @@ COPY Follows FROM "follows.Parquet";
 
 ### Relationship table with multiple `FROM-TO` pairs
 
-If a relationship table has multiple `FROM-TO` pairs, you need to specify which pair to insert through `from, to` options. For example
+If a relationship table has multiple `FROM-TO` pairs, you need to specify which pair to insert by specifying `from` and `to` parameters. For example:
 
 ```sql
-Copy Knows FROM 'knows_user_user.parquet' (from='User', to='User');
+COPY Knows FROM 'knows_user_user.parquet' (from='User', to='User');
 ```
 
 More information can be found [here](/cypher/data-definition/create-table).

--- a/src/content/docs/import/parquet.md
+++ b/src/content/docs/import/parquet.md
@@ -60,6 +60,16 @@ To load this Parquet file into a `Follows` table, simply run:
 COPY Follows FROM "follows.Parquet";
 ```
 
+### Relationship table with multiple `FROM-TO` pairs
+
+If a relationship table has multiple `FROM-TO` pairs, you need to specify which pair to insert through `from, to` options. For example
+
+```sql
+Copy Knows FROM 'knows_user_user.parquet' (from='User', to='User');
+```
+
+More information can be found [here](/cypher/data-definition/create-table).
+
 ## Import multiple files to a single table
 
 It is common practice to divide large Parquet files into several smaller files for cleaner data management.


### PR DESCRIPTION
Many users seem to unable find the interaction when copying into a relationship table with multiple from-to pairs. So I duplicate the instruction in Data Import section and links to the original instructions.