### PR TITLE
Update docs for multiquery

### DIFF
--- a/src/content/docs/client-apis/nodejs.mdx
+++ b/src/content/docs/client-apis/nodejs.mdx
@@ -104,3 +104,31 @@ for (const row of rows) {
 
 See the [Node.js API documentation](https://api-docs.kuzudb.com/nodejs/) for more details
 on the methods available in the sync and async APIs.
+
+## Run multiple queries in one execution
+
+Similarly, in the Node.js API, you can execute multiple Cypher queries separated by semicolons in a single execution.
+The API will return a list of `QueryResult` objects.
+
+```js
+// Async API
+const results = await conn.query("RETURN 1; RETURN 2; RETURN 3");
+for (const result of results) {
+  const rows = await result.getAll();
+  console.log(rows);
+}
+
+// Sync API
+const resultsSync = conn.querySync("RETURN 1; RETURN 2; RETURN 3");
+for (const result of resultsSync) {
+  const rows = result.getAllSync();
+  console.log(rows);
+}
+```
+
+Both versions will return:
+```
+[[1]]
+[[2]]
+[[3]]
+```

--- a/src/content/docs/client-apis/nodejs.mdx
+++ b/src/content/docs/client-apis/nodejs.mdx
@@ -110,23 +110,31 @@ on the methods available in the sync and async APIs.
 Similarly, in the Node.js API, you can execute multiple Cypher queries separated by semicolons in a single execution.
 The API will return a list of `QueryResult` objects.
 
+<Tabs>
+
+<TabItem label="Async API">
 ```js
-// Async API
 const results = await conn.query("RETURN 1; RETURN 2; RETURN 3");
 for (const result of results) {
   const rows = await result.getAll();
   console.log(rows);
 }
+```
+</TabItem>
 
-// Sync API
+<TabItem label="Sync API">
+```js
 const resultsSync = conn.querySync("RETURN 1; RETURN 2; RETURN 3");
 for (const result of resultsSync) {
   const rows = result.getAllSync();
   console.log(rows);
 }
 ```
+</TabItem>
 
-Both versions will return:
+</Tabs>
+
+This will return:
 ```
 [[1]]
 [[2]]

--- a/src/content/docs/client-apis/python.mdx
+++ b/src/content/docs/client-apis/python.mdx
@@ -121,6 +121,26 @@ appropriately and addressed in a future release.
 
 </Tabs>
 
+## Run multiple queries in one execution
+
+By default, executing a single query in the Python API will return a `QueryResult` object. However,
+if you submit multiple Cypher queries separated by semicolons in a single execution, the API will
+return a list of `QueryResult` objects.
+
+You can loop through each result of a `QueryResult` object and get its contents.
+```python
+response = conn.execute("RETURN 1; RETURN 2; RETURN 3")
+for row in response:
+    while row.has_next():
+        print(row.get_next())
+```
+This returns:
+```
+[1]
+[2]
+[3]
+```
+
 ## DataFrames and Arrow Tables
 
 In Python, Kuzu supports the use of Pandas and Polars DataFrames, as well as PyArrow Tables. This


### PR DESCRIPTION
A user asked us, "According to the Python documentation, the return value of `execute()` method is `QueryResult | list[QueryResult]`.  Under which circumstances will the result be a list?"

This is possible in the Node.js and Python APIs. This PR documents the condition under which this happens (when multiple Cypher queries separated by semicolons are sent in a single execution command).