### PR TITLE
Init nix installation docs

### DIFF
--- a/src/content/docs/installation.mdx
+++ b/src/content/docs/installation.mdx
@@ -16,10 +16,7 @@ executable with no dependencies that can be used to interact with a Kuzu databas
 <Tabs>
 <TabItem label="Linux">
 
-Use a tool like cURL to download the latest version of the Kuzu CLI to your local machine. Alternatively,
-simply copy-paste [this URL](https://github.com/kuzudb/kuzu/releases/download/v0.9.0/kuzu_cli-linux-x86_64.tar.gz)
-for x86-64 or [this one](https://github.com/kuzudb/kuzu/releases/download/v0.9.0/kuzu_cli-linux-aarch64.tar.gz)
-for aarch64 into your browser.
+Use a tool like cURL to download the latest version of the Kuzu CLI to your local machine.
 
 **x86-64**
 
@@ -53,7 +50,7 @@ brew install kuzu
 <TabItem label="Windows">
 
 Use a tool like cURL to download the latest version of the Kuzu CLI to your local machine. Alternatively,
-simply copy-paste [this HTTPS URL](https://github.com/kuzudb/kuzu/releases/download/v0.9.0/kuzu_cli-windows-x86_64.zip)
+simply copy-paste [this URL](https://github.com/kuzudb/kuzu/releases/download/v0.9.0/kuzu_cli-windows-x86_64.zip)
 into your browser.
 
 ```bash
@@ -66,12 +63,33 @@ From within the terminal, you can then run `./kuzu.exe`.
 
 </TabItem>
 
+<TabItem label="nix">
+
+On Linux, macOS, and WSL2, you can also use [`nix`](https://nix.dev) to run the Kuzu CLI.
+
+Run Kuzu in a temporary shell:
+
+```bash
+nix-shell -p kuzu
+kuzu
+``````
+
+Alternatively, you can install Kuzu declaratively using Home Manager or NixOS configuration:
+
+```nix
+{
+  environment.systemPackages = [ pkgs.nix ]; // NixOS
+  home.packages = [ pkgs.nix ];              // Home Manager
+}
+```
+</TabItem>
+
 </Tabs>
 
 ## Python
 
-You can use `uv` (recommended)  or `pip` to install the Kuzu Python client library.
-The instructions are the same for macOS, Linux, and Windows.
+You can use `uv` (recommended), `pip`, or `nix` to install the Kuzu Python client library.
+The instructions are the same for Linux, macOS, and Windows.
 
 <Tabs>
 
@@ -88,6 +106,14 @@ uv add kuzu
 
 ```bash
 pip install kuzu
+```
+
+</TabItem>
+
+<TabItem label="nix">
+
+```bash
+nix-shell -p "python3.withPackages (ps: [ ps.kuzu ])"
 ```
 
 </TabItem>

--- a/src/content/docs/installation.mdx
+++ b/src/content/docs/installation.mdx
@@ -63,9 +63,9 @@ From within the terminal, you can then run `./kuzu.exe`.
 
 </TabItem>
 
-<TabItem label="nix">
+<TabItem label="Nix">
 
-On Linux, macOS, and WSL2, you can also use [`nix`](https://nix.dev) to run the Kuzu CLI.
+On Linux, macOS, and WSL2, you can also use [`Nix`](https://nix.dev) to run the Kuzu CLI.
 
 Run Kuzu in a temporary shell:
 

--- a/src/content/docs/installation.mdx
+++ b/src/content/docs/installation.mdx
@@ -88,7 +88,7 @@ Alternatively, you can install Kuzu declaratively using Home Manager or NixOS co
 
 ## Python
 
-You can use `uv` (recommended), `pip`, or `nix` to install the Kuzu Python client library.
+You can use `uv`, `pip`, or `nix` to install the Kuzu Python client library.
 The instructions are the same for Linux, macOS, and Windows.
 
 <Tabs>


### PR DESCRIPTION
Initial set of installation instructions.

Not sure if I need to introduce what `nix` is or we expect users to already know if they are selecting this tab. In either case, the linked webpage explains `nix` and how to install it on all platforms.

TODO nix-shell configuration for C++ clients, but that can come later.

Closes #406