### PR TITLE
Remove trailing comma in Louvain call sample

### DIFF
--- a/src/content/docs/extensions/algo/louvain.mdx
+++ b/src/content/docs/extensions/algo/louvain.mdx
@@ -22,8 +22,8 @@ Kuzu implements a parallelized version of the Louvain algorithm based on [Grappo
 ```
 CALL louvain(
     graph_name,
-    maxPhases := 20, 
-    maxIterations := 20, 
+    maxPhases := 20,
+    maxIterations := 20
 )
 RETURN node, louvain_id
 ```


### PR DESCRIPTION
The sample of louvain call has a trailing comma after the last parameter. If we copy/paste this code (updating the `graph_name`), we get an error like:

```
The evaluation of this query failed with the following error:
Parser exception: Invalid input <CALL louvain(
    "graph",
    maxPhases := 20,
    maxIterations := 20,
)>: expected rule oC_Statement (line: 5, offset: 0)
")"
 ^
```
# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu-docs/blob/main/CLA.md).