### PR TITLE
Fix/489-deploy-pr-event

### DIFF
--- a/.github/workflows/deploy-dev-docs.yml
+++ b/.github/workflows/deploy-dev-docs.yml
@@ -25,6 +25,7 @@ jobs:
 
   docker:
     name: Build and push Docker image
+    # Restricting the docker job to push events to ensure Docker images are only built and pushed for finalized changes.
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/deploy-dev-docs.yml
+++ b/.github/workflows/deploy-dev-docs.yml
@@ -25,6 +25,7 @@ jobs:
 
   docker:
     name: Build and push Docker image
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -34,17 +35,17 @@ jobs:
 
       - name: Remove .git
         run: rm -rf .git
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Login to ghcr.io
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
This PR fixes #489

The `check-links` job already produces a build and will fail if there is an error.

The `docker` job should only run in a push event to `dev`.