### PR TITLE
Rename shell panel to query panel

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -163,10 +163,10 @@ export default defineConfig({
                             collapsed: true,
                             items: [
                                 { label: 'Intro to Kuzu Explorer', link: '/visualization/kuzu-explorer'},
-                                { label: 'Shell panel', link: '/visualization/kuzu-explorer/shell-panel'},
+                                { label: 'Query panel', link: '/visualization/kuzu-explorer/query-panel'},
                                 { label: 'Schema panel', link: '/visualization/kuzu-explorer/schema-panel' },
                                 { label: 'Import panel', link: '/visualization/kuzu-explorer/import-panel' },
-                                { label: 'Settings panel', link: '/visualization/kuzu-explorer/settings-panel' },
+                                { label: 'Settings panel', link: '/visualization/kuzu-explorer/settings' },
                             ],
                         },
                         {

--- a/src/content/docs/visualization/kuzu-explorer/import-panel.md
+++ b/src/content/docs/visualization/kuzu-explorer/import-panel.md
@@ -101,7 +101,7 @@ You can head over to the Schema tab to see the graph schema that was created fro
 <img src="/img/visualization/schema-panel.png" />
 
 That's it! You can now begin querying the data by heading over to the query editor in the
-[shell panel](/visualization/kuzu-explorer/shell-panel/).
+[query panel](/visualization/kuzu-explorer/query-panel/).
 
 ## Troubleshooting
 

--- a/src/content/docs/visualization/kuzu-explorer/index.mdx
+++ b/src/content/docs/visualization/kuzu-explorer/index.mdx
@@ -123,7 +123,7 @@ docker run -p 8000:8000 \
            --rm kuzudb/explorer:latest
 ```
 
-With this configuration, the data directory you specify on your host machine will be accessible as `/data` in the container. For example, in the shell panel, you can copy a CSV file into your database by running the following command:
+With this configuration, the data directory you specify on your host machine will be accessible as `/data` in the container. For example, in the query panel, you can copy a CSV file into your database by running the following command:
 
 ```cypher
 COPY Test FROM "test.csv" (HEADER=true);
@@ -138,8 +138,8 @@ You can refer to the corresponding cards below for more details.
 
 <CardGrid>
   <LinkCard
-    title="Shell panel"
-    href="/visualization/kuzu-explorer/shell-panel"
+    title="Query panel"
+    href="/visualization/kuzu-explorer/query-panel"
   />
   <LinkCard
     title="Schema panel"

--- a/src/content/docs/visualization/kuzu-explorer/query-panel.md
+++ b/src/content/docs/visualization/kuzu-explorer/query-panel.md
@@ -1,10 +1,10 @@
 ---
-title: Shell Panel
+title: Query Panel
 ---
 
 ## Query editor
 
-Using the Shell Panel, you can interactively issue queries to your loaded database
+Using the query panel, you can interactively issue queries to your loaded database
 and visualize the results in several different views. You issue queries by using
 the canvases on your screen, which have a red X and green play icon on the left side.
 You write your query on the top of a canvas and when you click the play button or press Shift+Enter,
@@ -21,7 +21,7 @@ There is a side panel in the graph view, which you can open and close to see the
 individual nodes and relationships you click on or hover over. The graph view is enabled
 and is the default view if the query's `RETURN` statement contains node (and relationship) variables.
 For example if the query about returned only the name property of `a` nodes, i.e.,
-if the return statement was `RETURN a.name`, then you could not see the results in a graph view,
+if the return statement was `RETURN a.name`, then you would not see the results in a graph view,
 as the return values are only a column of strings. As long as one of the variables projected
 in the `RETURN` statement is a node you will get by default a graph view.
 
@@ -73,9 +73,9 @@ CALL progress_bar=true;
 
 To further configure the progress bar, see the [configuration](/cypher/configuration) section.
 
-## LLM integration
+## AI query generation
 
-The shell panel has an additional tab called "AI Query" that allows you to use LLMs from OpenAI or other OpenAI-compatible
+The Query panel has an additional tab called "AI Query" that allows you to use LLMs from OpenAI or other OpenAI-compatible
 APIs to generate Cypher queries from natural language.
 
 ### OpenAI models
@@ -87,7 +87,7 @@ and select the desired OpenAI model. Copy-paste your OpenAI API key into API key
 
 ### Open-AI compatible endpoints
 
-The shell panel supports Open-AI compatible endpoints that are not OpenAI models, for example, [Ollama](https://ollama.com/).
+The Query panel supports Open-AI compatible endpoints that are not OpenAI models, for example, [Ollama](https://ollama.com/).
 To use endpoints like these, select the "Open-AI compatible endpoint" option in the "Query Generation Options" section.
 For open source models, no API key is needed. The screenshot below shows the settings for using Ollama with the `gemma3:27b` model
 for query generation.
@@ -104,7 +104,7 @@ docker run --net=host --rm kuzudb/explorer:latest
 ```
 :::
 
-### AI query generation
+### Use LLMs to generate Cypher queries
 
 You can now use the AI Query tab to generate Cypher queries from natural language. Simply type in the natural language query and
 run the cell. This will generate a Cypher query using the selected LLM, which you can inspect by clicking back on the "Cypher Query" tab.


### PR DESCRIPTION
Based on the new UI, we rename the "shell panel" to "query panel".