### PR TITLE
Add documentation for Ruby/Nim APIs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -212,7 +212,9 @@ export default defineConfig({
                         { label: 'C++', link: '/client-apis/cpp' },
                         { label: 'C', link: '/client-apis/c' },
                         { label: '.NET', link: '/client-apis/net', badge: { text: 'Community', variant: 'caution'}},
-                        { label: 'Elixir', link: '/client-apis/elixir', badge: { text: 'Community', variant: 'caution'}}
+                        { label: 'Elixir', link: '/client-apis/elixir', badge: { text: 'Community', variant: 'caution'}},
+                        { label: 'Ruby', link: '/client-apis/ruby', badge: { text: 'Community', variant: 'caution'}},
+                        { label: 'Nim', link: '/client-apis/nim', badge: { text: 'Community', variant: 'caution'}},
                     ],
                 },
                 { label: 'Kuzu-Wasm', link: '/client-apis/wasm' },

--- a/src/content/docs/client-apis/index.mdx
+++ b/src/content/docs/client-apis/index.mdx
@@ -64,4 +64,15 @@ unsupported. The following client libraries have been contributed by the communi
     title="Elixir"
     href="/client-apis/elixir"
   />
+
+  <LinkCard
+    title="Ruby"
+    href="/client-apis/ruby"
+  />
+
+  <LinkCard
+    title="Nim"
+    href="/client-apis/nim"
+  />
+
 </CardGrid>

--- a/src/content/docs/client-apis/nim.mdx
+++ b/src/content/docs/client-apis/nim.mdx
@@ -1,0 +1,17 @@
+---
+title: Nim API
+---
+
+import { LinkCard } from '@astrojs/starlight/components';
+
+The Nim client is an independent, external project created by third-party contributors.
+You can find its API docs by clicking on the link card below, which takes you directly to the
+Nimble package page for `nim-kuzu`.
+
+Please contact the maintainer or post an issue on the project's
+[GitHub repository](https://github.com/mahlonsmith/nim-kuzu) if you have any issues using this API.
+
+<LinkCard
+  title="Nim API documentation"
+  href="https://code.martini.nu/fossil/nim-kuzu/doc/tip/README.md"
+/>

--- a/src/content/docs/client-apis/ruby.mdx
+++ b/src/content/docs/client-apis/ruby.mdx
@@ -1,0 +1,17 @@
+---
+title: Ruby API
+---
+
+import { LinkCard } from '@astrojs/starlight/components';
+
+The Ruby client is an independent, external project created by third-party contributors.
+You can find its API docs by clicking on the link card below, which takes you directly to the
+RubyGems page for `ruby-kuzu`.
+
+Please contact the maintainer or post an issue on the project's
+[GitHub repository](https://github.com/ged/ruby-kuzu) if you have any issues using this API.
+
+<LinkCard
+  title="Ruby API documentation"
+  href="https://rubygems.org/gems/ruby-kuzu"
+/>


### PR DESCRIPTION
Closes #503. Points to two new third-party integration docs (Ruby and Nim).

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu-docs/blob/main/CLA.md).
