### PR TITLE
Add `llms.txt`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ pnpm-debug.log*
 # macOS-specific files
 .DS_Store
 .vscode
+public/llms.txt

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,9 @@
         "astro": "^5.5.6",
         "sharp": "^0.33.5",
         "starlight-links-validator": "^0.14.3"
+      },
+      "devDependencies": {
+        "gray-matter": "^4.0.3"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -2548,6 +2551,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/estree-util-attach-comments": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
@@ -2663,6 +2680,19 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
@@ -2717,6 +2747,46 @@
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/h3": {
       "version": "1.15.1",
@@ -3257,6 +3327,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3331,6 +3411,16 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/kleur": {
@@ -5259,6 +5349,20 @@
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "license": "ISC"
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
@@ -5406,6 +5510,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/starlight-links-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/starlight-links-validator/-/starlight-links-validator-0.14.3.tgz",
@@ -5480,6 +5591,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/style-to-js": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro build",
+    "build": "npm run generate-llms && astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "check-links": "CHECK_LINKS=true astro build"
+    "check-links": "CHECK_LINKS=true astro build",
+    "generate-llms": "node scripts/generate-llms.cjs"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^6.3.1",
@@ -17,5 +18,8 @@
     "astro": "^5.5.6",
     "sharp": "^0.33.5",
     "starlight-links-validator": "^0.14.3"
+  },
+  "devDependencies": {
+    "gray-matter": "^4.0.3"
   }
 }

--- a/scripts/generate-llms.cjs
+++ b/scripts/generate-llms.cjs
@@ -6,6 +6,8 @@ const docsDir = path.join(__dirname, '../src/content/docs');
 const outputFile = path.join(__dirname, '../public/llms.txt');
 const baseUrl = 'https://docs.kuzudb.com';
 
+const header = "# Kuzu Documentation\n\n> Comprehensive documentation for Kuzu, an embedded (in-process), scalable, blazing fast graph database.\n";
+
 // Node structure for the directory tree
 function TreeNode(name, isDir, filePath = null, title = null) {
   return {
@@ -67,11 +69,13 @@ function generateMarkdown(node, depth = 0) {
       .split('-')
       .map(word => word.charAt(0).toUpperCase() + word.slice(1))
       .join(' ');
-    content += `## ${sectionName}\n\n`;
-  } else if (depth === 0 && node.name === 'root') {
-    // Add Root section for top-level files
-    content += `## Root\n\n`;
+    content += `\n## ${sectionName}\n\n`;
   }
+
+//   else if (depth === 0 && node.name === 'root') {
+//     // Add Root section for top-level files
+//     content += `\n## Root\n\n`;
+//   }
 
   // Process children
   node.children.forEach(child => {
@@ -99,7 +103,7 @@ function getMarkdownFiles(dir) {
     const stat = fs.statSync(filePath);
     if (stat && stat.isDirectory()) {
       results = results.concat(getMarkdownFiles(filePath));
-    } else if (file.endsWith('.md') || fileEndsWith('.mdx')) {
+    } else if (file.endsWith('.md') || file.endsWith('.mdx')) {
       results.push(filePath);
     }
   });
@@ -119,6 +123,28 @@ if (mdFiles.length === 0) {
   process.exit(0);
 }
 
-const tree = buildTree(mdFiles);
-const content = generateMarkdown(tree);
-fs.writeFileSync(outputFile, content);
+// Main execution
+try {
+  if (!fs.existsSync(docsDir)) {
+    console.error("Documentation directory does not exist:", docsDir);
+    process.exit(1);
+  }
+
+  const mdFiles = getMarkdownFiles(docsDir);
+  if (mdFiles.length === 0) {
+    console.warn("No Markdown files found in:", docsDir);
+    fs.writeFileSync(outputFile, "");
+    console.log("Created empty llms.txt at:", outputFile);
+    return;
+  }
+
+  const tree = buildTree(mdFiles);
+  const content = generateMarkdown(tree);
+  const finalContent = header + content;
+  fs.writeFileSync(outputFile, finalContent);
+  console.log("Successfully generated llms.txt at:", outputFile);
+} catch (error) {
+  console.error("Error generating llms.txt:", error.message);
+  process.exit(1);
+}
+

--- a/scripts/generate-llms.js
+++ b/scripts/generate-llms.js
@@ -1,0 +1,124 @@
+const fs = require('fs');
+const path = require('path');
+const matter = require('gray-matter');
+
+const docsDir = path.join(__dirname, '../src/content/docs');
+const outputFile = path.join(__dirname, '../public/llms.txt');
+const baseUrl = 'https://docs.kuzudb.com';
+
+// Node structure for the directory tree
+function TreeNode(name, isDir, filePath = null, title = null) {
+  return {
+    name,
+    isDir,
+    filePath,
+    title,
+    children: [],
+  };
+}
+
+// Build a tree from file paths
+function buildTree(files) {
+  const root = TreeNode('root', true);
+  files.forEach(file => {
+    const relativePath = path.relative(docsDir, file);
+    const parts = relativePath.split(path.sep);
+    let current = root;
+
+    // Traverse or create directories
+    for (let i = 0; i < parts.length - 1; i++) {
+      let child = current.children.find(c => c.name === parts[i] && c.isDir);
+      if (!child) {
+        child = TreeNode(parts[i], true);
+        current.children.push(child);
+      }
+      current = child;
+    }
+
+    // Add the file
+    const data = fs.readFileSync(file, 'utf8');
+    const matterResult = matter(data);
+    const title = matterResult.data.title || path.basename(file, path.extname(file));
+    const fileNode = TreeNode(parts[parts.length - 1], false, file, title);
+    current.children.push(fileNode);
+  });
+
+  // Sort children: directories first, then files, both alphabetically
+  function sortNode(node) {
+    node.children.sort((a, b) => {
+      if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+    node.children.forEach(sortNode);
+  }
+  sortNode(root);
+
+  return root;
+}
+
+// Generate Markdown with sections and links
+function generateMarkdown(node, depth = 0) {
+  let content = '';
+
+  // Process the current node (skip root)
+  if (depth === 1 && node.isDir && node.name !== 'root') {
+    // Capitalize and replace hyphens with spaces for section name
+    const sectionName = node.name
+      .split('-')
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+    content += `## ${sectionName}\n\n`;
+  } else if (depth === 0 && node.name === 'root') {
+    // Add Root section for top-level files
+    content += `## Root\n\n`;
+  }
+
+  // Process children
+  node.children.forEach(child => {
+    if (child.isDir) {
+      // Recurse into directories
+      content += generateMarkdown(child, depth + 1);
+    } else {
+      // Output file as a Markdown link
+      const relativePath = path.relative(docsDir, child.filePath);
+      const urlPath = relativePath.replace(/\.(md|mdx)$/, '');
+      const fullUrl = `${baseUrl}/${urlPath}`;
+      content += `- [${child.title}](${fullUrl}): ${child.title}\n`;
+    }
+  });
+
+  return content;
+}
+
+// Get all Markdown files
+function getMarkdownFiles(dir) {
+  let results = [];
+  const list = fs.readdirSync(dir);
+  list.forEach(file => {
+    const filePath = path.join(dir, file);
+    const stat = fs.statSync(filePath);
+    if (stat && stat.isDirectory()) {
+      results = results.concat(getMarkdownFiles(filePath));
+    } else if (file.endsWith('.md') || fileEndsWith('.mdx')) {
+      results.push(filePath);
+    }
+  });
+  return results;
+}
+
+// Main execution
+if (!fs.existsSync(docsDir)) {
+  console.error('Documentation directory does not exist:', docsDir);
+  process.exit(1);
+}
+
+const mdFiles = getMarkdownFiles(docsDir);
+if (mdFiles.length === 0) {
+  console.warn('No Markdown files found in:', docsDir);
+  fs.writeFileSync(outputFile, '');
+  process.exit(0);
+}
+
+const tree = buildTree(mdFiles);
+const content = generateMarkdown(tree);
+fs.writeFileSync(outputFile, content);

--- a/src/content/docs/extensions/full-text-search.md
+++ b/src/content/docs/extensions/full-text-search.md
@@ -1,5 +1,5 @@
 ---
-title: "Full Text Search"
+title: "Full-text Search (FTS)"
 ---
 
 ## Usage


### PR DESCRIPTION
As per the new [llms.txt](https://llmstxt.org/) spec, we now add a `llms.txt` file to the `dist/` directory as the site is built so that we can point LLMs to the right part of the docs using IDEs like Cursor.