### PR TITLE
 fix-use-before-init-error-in-vector-example

### DIFF
--- a/src/content/docs/extensions/vector.mdx
+++ b/src/content/docs/extensions/vector.mdx
@@ -205,14 +205,6 @@ import kuzu
 
 use_llm_extension = True # Set to `False` to use sentence_transformers
 
-if use_llm_extension:
-    conn.execute("INSTALL llm; LOAD llm;")
-else:
-    from sentence_transformers import SentenceTransformer
-    # Load a pre-trained embedding generation model
-    # https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2
-    model = SentenceTransformer("all-MiniLM-L6-v2")
-
 DB_NAME = "ex_kuzu_db"
 
 # Initialize the database
@@ -222,6 +214,14 @@ conn = kuzu.Connection(db)
 # Install and load vector extension once again
 conn.execute("INSTALL VECTOR;")
 conn.execute("LOAD VECTOR;")
+
+if use_llm_extension:
+    conn.execute("INSTALL llm; LOAD llm;")
+else:
+    from sentence_transformers import SentenceTransformer
+    # Load a pre-trained embedding generation model
+    # https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2
+    model = SentenceTransformer("all-MiniLM-L6-v2")
 
 if use_llm_extension:
     os.environ["OPENAI_API_KEY"] = "sk-proj-key" # Replace with your own OpenAI API key


### PR DESCRIPTION
# Contributor agreement

#520 Introduced some examples to the vector docs on how to use the embedding function. There were use before init errors with the conn variable. This is one error I had missed having not broken each snippet into its own script. Merging without review since this is just a reordering of code (similar to one from the original PR).

- [X] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu-docs/blob/main/CLA.md).
