### PR TITLE
Document Update Extension

### DIFF
--- a/src/content/docs/extensions/index.mdx
+++ b/src/content/docs/extensions/index.mdx
@@ -52,6 +52,13 @@ INSTALL <EXTENSION_NAME>;
 ```
 You only need to install an extension once. 
 
+### Update an official extension
+To update an official extension you can use the `UPDATE` command:
+
+```sql
+UPDATE <EXTENSION_NAME>;
+```
+
 ### Force install an official extension
 If you run the `INSTALL` command for an extension that is already installed, the second install command will not perform any action.
 

--- a/src/content/docs/extensions/index.mdx
+++ b/src/content/docs/extensions/index.mdx
@@ -53,13 +53,13 @@ INSTALL <EXTENSION_NAME>;
 You only need to install an extension once. 
 
 ### Update an official extension
+
 To update an official extension you can use the `UPDATE` command:
 
 ```sql
 UPDATE <EXTENSION_NAME>;
 ```
 
-### Force install an official extension
 If you run the `INSTALL` command for an extension that is already installed, the second install command will not perform any action.
 
 If you want to forcefully download an extension for any reason, for example if the extension is not working properly, you can use the `FORCE INSTALL` command:


### PR DESCRIPTION
# Contributor agreement

Found this while working on tests for the new release. We have an error message telling users how to update if they try installing an extension that's already installed. 
See `kuzuRoot/src/processor/operator/simple/install_extension.cpp:setOutputMessage`
We should add similar instructions in our docs.

- [X] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu-docs/blob/main/CLA.md).
