### PR TITLE
update llm docs

### DIFF
--- a/src/content/docs/extensions/llm.mdx
+++ b/src/content/docs/extensions/llm.mdx
@@ -32,9 +32,7 @@ The `CREATE_EMBEDDING` function allows you to create embeddings from text using 
 * [OpenAI](https://platform.openai.com/docs/guides/embeddings)
 * [Voyage AI](https://docs.voyageai.com/docs/embeddings)
 
-The general form of the
-function is shown below. The first three arguments are required, and the last two arguments are
-only required if the provider supports region configuration (for e.g., `amazon-bedrock` or `google-vertex`. Kuzu does not assume a default region. It returns an embedding of type `LIST[FLOAT]`.
+The general form of the function is shown below. It returns an embedding of type `LIST[FLOAT]`.
 
 ```cypher
 CREATE_EMBEDDING(
@@ -50,21 +48,23 @@ CREATE_EMBEDDING(
 
 Required arguments:
 
-- `prompt`: The input text to embed.
+- `PROMPT`: The input text to embed.
     - Type: `STRING`
-- `provider`: The embedding provider.
+- `PROVIDER`: The embedding provider.
     - Type: `STRING`
-- `model`: The identifier of the embedding model.
+- `MODEL`: The identifier of the embedding model.
     - Type: `STRING`
 
 Optional arguments:
 
-- `dimensions`: The size of the embedding vector.
+- `DIMENSIONS`: The size of the embedding vector.
     - Type: `INT64`
+    - Default: See provider API reference
     - Note: This value must be positive.
-- `region`: The region to send requests to.
+- `REGION`: The region to send requests to.
     - Type: `STRING`
-- `endpoint`: The endpoint to send requests to.
+    - Default: `None` (If a provider supports this argument it must be specified).
+- `ENDPOINT`: The endpoint to send requests to.
     - Type: `STRING`
     - Default: `http://localhost:11434`
 

--- a/src/content/docs/extensions/llm.mdx
+++ b/src/content/docs/extensions/llm.mdx
@@ -4,14 +4,14 @@ title: "LLM extension"
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-The `llm` extension allows you to use LLMs from different providers directly from Kuzu using Cypher.
+The `llm` extension helps you run LLM-based workflows directly within Kuzu using Cypher.
 
 Currently, this extension provides the following function:
 
 - `CREATE_EMBEDDING`: Create embeddings from text
 
 :::note[Note]
-In the future, we plan to add more functions to this extension, such as sending queries to LLMs directly from Kuzu.
+We plan to add more functions to this extension in the future, such as sending queries to LLMs directly from Kuzu.
 :::
 
 ## Usage
@@ -40,9 +40,10 @@ CREATE_EMBEDDING(
     <PROMPT>,
     <PROVIDER>,
     <MODEL>
-    // Optional provider-specific arguments
+    // Provider-specific arguments
     <DIMENSIONS>,
-    <REGION or ENDPOINT>
+    <REGION>,
+    <ENDPOINT>
 );
 ```
 
@@ -55,29 +56,29 @@ Required arguments:
 - `MODEL`: The identifier of the embedding model.
     - Type: `STRING`
 
-Optional arguments:
+Additional provider-specific arguments:
 
 - `DIMENSIONS`: The size of the embedding vector.
     - Type: `INT64`
-    - Default: See provider API reference
     - Note: This value must be positive.
 - `REGION`: The region to send requests to.
     - Type: `STRING`
-    - Default: `None` (If a provider supports this argument it must be specified).
+    - Note: This value is required when the provider supports it.
 - `ENDPOINT`: The endpoint to send requests to.
     - Type: `STRING`
     - Default: `http://localhost:11434`
 
-The following table shows the optional arguments supported by each provider:
+The additional arguments that you can use depends on the provider. The following table shows
+the arguments associated with each provider:
 
 | Provider | `dimensions` | `region` | `endpoint` |
 | --- | --- | --- | --- |
-| `amazon-bedrock` | - | Yes | - |
-| `google-vertex` | Yes | Yes | - |
+| `amazon-bedrock` | - | Required | - |
+| `google-vertex` | Optional | Required | - |
 | `google-gemini` | - | - | - |
-| `open-ai` | Yes | - | - |
-| `voyage-ai` | Yes | - | - |
-| `ollama` | - | - | Yes |
+| `open-ai` | Optional | - | - |
+| `voyage-ai` | Optional | - | - |
+| `ollama` | - | - | Optional |
 
 :::note[Note]
 If an unsupported model, dimension, region, or endpoint is specified, the API call to the provider will fail. Check the provider's API documentation for the currently supported options.

--- a/src/content/docs/extensions/llm.mdx
+++ b/src/content/docs/extensions/llm.mdx
@@ -100,44 +100,31 @@ To allow API calls to the providers, you must set the appropriate environment va
 ### Examples
 
 ```cypher
-RETURN CREATE_EMBEDDING(
-    "Hello world",
-    "amazon-bedrock",
-    "amazon.titan-embed-text-v1",
-    "us-east-1"                          // Optional region
-);
+// Required REGION
+RETURN CREATE_EMBEDDING("Hello world", "amazon-bedrock", "amazon.titan-embed-text-v1", "us-east-1");
 
-RETURN CREATE_EMBEDDING(
-    "Hello world",
-    "google-gemini",
-    "gemini-embedding-exp-03-07"
-);
-RETURN CREATE_EMBEDDING(
-    "Hello world",
-    "google-vertex",
-    "gemini-embedding-001",
-    256,                                // Optional dimensions
-    "us-east1"                          // Optional region
-);
+RETURN CREATE_EMBEDDING("Hello world", "google-gemini", "gemini-embedding-exp-03-07");
 
-RETURN CREATE_EMBEDDING(
-    "Hello world",
-    "ollama",
-    "nomic-embed-text"
-);
-RETURN CREATE_EMBEDDING(
-    "Hello world",
-    "ollama",
-    "nomic-embed-text",
-    "http://endpoint.example.com:8000" // Optional endpoint
-);
+// Required REGION
+RETURN CREATE_EMBEDDING("Hello world", "google-vertex", "gemini-embedding-001", "us-east1");
 
-RETURN CREATE_EMBEDDING(
-    "Hello world",
-    "voyage-ai",
-    "voyage-3-large",
-    512                                 // Optional dimensions
-);
+// Optional DIMENSIONS and Required REGION.
+RETURN CREATE_EMBEDDING("Hello world", "google-vertex", "gemini-embedding-001", 256, "us-east1");
+
+RETURN CREATE_EMBEDDING("Hello world", "ollama", "nomic-embed-text");
+
+// Optional ENDPOINT
+RETURN CREATE_EMBEDDING("Hello world", "ollama", "nomic-embed-text", "http://endpoint.example.com:8000");
+
+RETURN CREATE_EMBEDDING( "Hello world", "open-ai", "text-embedding-3-small");
+
+// Optional DIMENSIONS
+RETURN CREATE_EMBEDDING( "Hello world", "open-ai", "text-embedding-3-small", 512);
+
+RETURN CREATE_EMBEDDING( "Hello world", "voyage-ai", "voyage-3-large");
+
+// Optional DIMENSIONS
+RETURN CREATE_EMBEDDING( "Hello world", "voyage-ai", "voyage-3-large", 512);
 ```
 
 ### Storing embeddings in a vector index


### PR DESCRIPTION
# Contributor agreement
[DO NOT MERGE expect changes from @sdht0]

1. I cannot agree with

`The first three arguments are required, and the last two arguments are only required if the provider supports region configuration`


It is a contradictory statement (the way I read it is that we must specify dimensions if we need to specify region). The example in the docs

```
RETURN CREATE_EMBEDDING(
    "Hello world",
    "amazon-bedrock",
    "amazon.titan-embed-text-v1",
    "us-east-1"                          
);
```

specifies a region but does not specify dimensions. 
I have moved and updated this note where the description for the region argument lies. 

2. Update note for default values on the optional params.

3. Some minor cleaning

- [X] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu-docs/blob/main/CLA.md).
