### PR TITLE
Rust tutorial fixes

### DIFF
--- a/src/content/docs/tutorials/rust/index.mdx
+++ b/src/content/docs/tutorials/rust/index.mdx
@@ -150,8 +150,8 @@ See the documentation on [importing data](/import/csv) for more details on the p
 
 Finally, we can print out a list of tables:
 ```rs
-let mut result = conn.query("CALL SHOW_TABLES() RETURN *")?;
-println!("{}", result.display());
+let result = conn.query("CALL SHOW_TABLES() RETURN *")?;
+println!("{}", result);
 ```
 ### Running the code
 
@@ -160,10 +160,10 @@ Run `create_db.rs` to create the Kuzu database and import the CSV files:
 $ cargo run --bin create_db
 id|name|type|database name|comment
 0|User|NODE|local(kuzu)|
-2|FOLLOWS|REL|local(kuzu)|
 1|Post|NODE|local(kuzu)|
-3|POSTS|REL|local(kuzu)|
-4|LIKES|REL|local(kuzu)|
+3|FOLLOWS|REL|local(kuzu)|
+5|POSTS|REL|local(kuzu)|
+7|LIKES|REL|local(kuzu)|
 ```
 The CSV data has been copied into a new Kuzu database in `social_network.kuzu`.
 
@@ -201,12 +201,12 @@ cargo run --bin kuzu_social_network
 
 First, we use a simple `MATCH` query to list some users who are followed by some other user:
 ```rs
-let mut result1 = conn.query(
+let result1 = conn.query(
     "MATCH (u1:User)-[f:FOLLOWS]->(u2:User)
     RETURN u2.username
     LIMIT 5",
 )?;
-println!("{}", result1.display());
+println!("{}", result1);
 ```
 
 Returns:
@@ -223,12 +223,12 @@ For each relation `FOLLOWS`, this will simply return the followee's username of 
 
 Let's count the number of appearances of a followee by using the `COUNT()` function:
 ```rs
-let mut result2 = conn.query(
+let result2 = conn.query(
     "MATCH (u1:User)-[f:FOLLOWS]->(u2:User)
     RETURN u2.username, COUNT(u2) AS follower_count
     LIMIT 5",
 )?;
-println!("{}", result2.display());
+println!("{}", result2);
 ```
 Returns
 ```
@@ -244,13 +244,13 @@ This is a lot more useful! We can now clearly see how many followers each user h
 Lastly, we use `ORDER BY` and `LIMIT` to order the usernames by their followers count, and
 return only the first entry. This is one of the users we are looking for, including the count of how many followers that user has:
 ```rs
-let mut result3 = conn.query(
+let result3 = conn.query(
     "MATCH (u1:User)-[f:FOLLOWS]->(u2:User)
     RETURN u2.username, COUNT(u2) AS follower_count
     ORDER BY follower_count DESC
     LIMIT 1",
 )?;
-println!("{}", result3.display());
+println!("{}", result3);
 ```
 Returns:
 ```
@@ -277,13 +277,13 @@ For example, how many follows does it take to get from user `silentguy245` to `e
 
 We can query this by using a [recursive match](/cypher/query-clauses/match) to find the shortest path length:
 ```rs
-let mut result4 = conn.query(
+let result4 = conn.query(
     "MATCH p = (u1:User)-[f:FOLLOWS* SHORTEST]->(u2:User)
     WHERE u1.username = 'silentguy245'
     AND u2.username = 'epicwolf202'
     RETURN p",
 )?;
-println!("{}", result4.display());
+println!("{}", result4);
 ```
 Returns:
 ```
@@ -293,13 +293,13 @@ This will return a result of the `RECURSIVE_REL` datatype, which as you can see 
 
 To make this more useful, we will collect just the usernames in the path by using a [recursive relationship function](/cypher/expressions/recursive-rel-functions)
 ```rs
-let mut result5 = conn.query(
+let result5 = conn.query(
     "MATCH p = (u1:User)-[f:FOLLOWS* SHORTEST]->(u2:User)
     WHERE u1.username = 'silentguy245'
     AND u2.username = 'epicwolf202'
     RETURN PROPERTIES(NODES(p), 'username')",
 )?;
-println!("{}", result5.display());
+println!("{}", result5);
 ```
 Returns:
 ```
@@ -315,11 +315,11 @@ user, `mysticwolf198`, in between them.
 To answer this query, we will follow a similar approach as Q1. We first count the number of 3-hop queries:
 
 ```rs
-let mut result6 = conn.query(
+let result6 = conn.query(
     "MATCH (u1:User)-[f1:FOLLOWS]->(u2:User)-[f2:Follows]->(u3:User)-[f3:FOLLOWS]->(u4:User)
     RETURN COUNT(u4)",
 )?;
-println!("{}", result6.display());
+println!("{}", result6);
 ```
 Returns:
 ```
@@ -350,8 +350,8 @@ let params = vec![
     ("userdst", Value::String(userdst.to_string())),
     ("userint", Value::String(userint.to_string())),
 ];
-let mut result7 = conn.execute(&mut prepared_query, params)?;
-println!("{}", result7.display());
+let result7 = conn.execute(&mut prepared_query, params)?;
+println!("{}", result7);
 ```
 Returns:
 ```
@@ -424,8 +424,8 @@ fn main() -> Result<(), Error> {
     conn.query("COPY POSTS FROM './tutorial_data/relation/POSTS.csv'")?;
     conn.query("COPY LIKES FROM './tutorial_data/relation/LIKES.csv'")?;
 
-    let mut result = conn.query("CALL SHOW_TABLES() RETURN *")?;
-    println!("{}", result.display());
+    let result = conn.query("CALL SHOW_TABLES() RETURN *")?;
+    println!("{}", result);
 
     Ok(())
 }
@@ -441,49 +441,49 @@ fn main() -> Result<(), Error> {
     let db = Database::new("social_network.kuzu", SystemConfig::default())?;
     let conn = Connection::new(&db)?;
 
-    let mut result1 = conn.query(
+    let result1 = conn.query(
         "MATCH (u1:User)-[f:FOLLOWS]->(u2:User)
         RETURN u2.username
         LIMIT 5",
     )?;
-    println!("{}", result1.display());
+    println!("{}", result1);
 
-    let mut result2 = conn.query(
+    let result2 = conn.query(
         "MATCH (u1:User)-[f:FOLLOWS]->(u2:User)
         RETURN u2.username, count(u2) as follower_count
         LIMIT 5",
     )?;
-    println!("{}", result2.display());
+    println!("{}", result2);
 
-    let mut result3 = conn.query(
+    let result3 = conn.query(
         "MATCH (u1:User)-[f:FOLLOWS]->(u2:User)
         RETURN u2.username, count(u2) as follower_count
         ORDER BY follower_count DESC
         LIMIT 1",
     )?;
-    println!("{}", result3.display());
+    println!("{}", result3);
 
-    let mut result4 = conn.query(
+    let result4 = conn.query(
         "MATCH p = (u1:user)-[f:FOLLOWS* SHORTEST 1..4]->(u2:User)
         WHERE u1.username = 'silentguy245'
         AND u2.username = 'epicwolf202'
         RETURN p",
     )?;
-    println!("{}", result4.display());
+    println!("{}", result4);
 
-    let mut result5 = conn.query(
+    let result5 = conn.query(
         "MATCH p = (u1:user)-[f:FOLLOWS* SHORTEST 1..4]->(u2:User)
         WHERE u1.username = 'silentguy245'
         AND u2.username = 'epicwolf202'
         RETURN properties(nodes(p), 'username')",
     )?;
-    println!("{}", result5.display());
+    println!("{}", result5);
 
-    let mut result6 = conn.query(
+    let result6 = conn.query(
         "MATCH (u1:User)-[f1:FOLLOWS]->(u2:User)-[f2:Follows]->(u3:User)-[f3:FOLLOWS]->(u4:User)
         RETURN count(u4)",
     )?;
-    println!("{}", result6.display());
+    println!("{}", result6);
 
     let query =
         "MATCH (u1:User)-[f1:FOLLOWS]->(u2:User)-[f2:Follows]->(u3:User)-[f3:FOLLOWS]->(u4:User)
@@ -498,8 +498,8 @@ fn main() -> Result<(), Error> {
         ("userdst", Value::String(u2.to_string())),
         ("userint", Value::String(u3.to_string())),
     ];
-    let mut result7 = conn.execute(&mut prepared_query, params)?;
-    println!("{}", result7.display());
+    let result7 = conn.execute(&mut prepared_query, params)?;
+    println!("{}", result7);
 
     Ok(())
 }


### PR DESCRIPTION
Some minor fixes for the Rust tutorial. Most importantly, `.display()` is not a method for query results -- they implement the `Display` trait.