### PR TITLE
Update Kuzu Explorer Instructions to align with https://github.com/kuzudb/explorer/pull/295

### DIFF
--- a/src/content/docs/visualization/kuzu-explorer/index.mdx
+++ b/src/content/docs/visualization/kuzu-explorer/index.mdx
@@ -33,12 +33,12 @@ To access an existing Kuzu database, you can mount its path to the `/database` d
 
 ```bash
 docker run -p 8000:8000 \
-           -v /absolute/path/to/database:/database \
+           -v {path to the directory containing the database file}:/database \
+           -e KUZU_FILE={database file name} \
            --rm kuzudb/explorer:latest
 ```
 
-By mounting local database files to Docker via `-v /absolute/path/to/database:/database`,
-the changes done in the UI will persist to the local database files after the UI is shutdown.
+By mounting local database files to Docker via `-v {path to the directory containing the database file}` and `-e KUZU_FILE={database file name}`, the changes done in the UI will persist to the local database files after the UI is shutdown. If the directory is mounted but the `KUZU_FILE` environment variable is not set, Kuzu Explorer will look for a file named `database.kz` in the mounted directory or create a new database file named `database.kz` in the mounted directory if it does not exist.
 
 The `--rm` flag tells docker that the container should automatically be removed after we close docker.
 


### PR DESCRIPTION
I noticed the Kuzu Explorer documentation is outdated on the docs site, so this PR just copies the copy verbatim from https://github.com/kuzudb/explorer/pull/295, which brings the docs up-to-date.

Closes #601 unless other changes were expected.

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu-docs/blob/main/CLA.md).
