### PR TITLE
Fix vector index property_name type requirement

### DIFF
--- a/src/content/docs/extensions/vector.mdx
+++ b/src/content/docs/extensions/vector.mdx
@@ -185,7 +185,7 @@ CALL CREATE_VECTOR_INDEX(
 Required arguments:
 - `TABLE_NAME`: The node table containing a property on which the index is to be created.
 - `INDEX_NAME`: The name of the vector index.
-- `PROPERTY_NAME`: The name of the vector property on which the index is to be created. The property must be a `LIST` or `ARRAY` of type `FLOAT` or `DOUBLE`.
+- `PROPERTY_NAME`: The name of the vector property on which the index is to be created. The property must be an `ARRAY` of type `FLOAT` or `DOUBLE`.
 
 Optional arguments to tune the index:
 


### PR DESCRIPTION
Vector indexes only support ARRAY columns, not LIST columns as currently documented. Update PROPERTY_NAME description to reflect actual behavior.

Reproducible example:

```python
import kuzu

print(kuzu.version)  # 0.11.1

db = kuzu.Database(":memory:")
conn = kuzu.Connection(db)

conn.execute("INSTALL VECTOR")
conn.execute("LOAD VECTOR")

# Based on https://docs.kuzudb.com/cypher/data-types/list-and-array

conn.execute("CREATE NODE TABLE Test1(id SERIAL PRIMARY KEY, vec FLOAT[1])")  # → ARRAY of FLOAT
conn.execute("CREATE NODE TABLE Test2(id SERIAL PRIMARY KEY, vec FLOAT[])")   # → LIST of FLOAT

# ✅ works with float ARRAY
conn.execute("CALL CREATE_VECTOR_INDEX('Test1', 'test1_vec_idx', 'vec')")

try:
    # ⛔ fails with float LIST
    conn.execute("CALL CREATE_VECTOR_INDEX('Test2', 'test2_vec_idx', 'vec')")
except RuntimeError as e:
    print(e)  # Binder exception: VECTOR_INDEX only supports FLOAT/DOUBLE ARRAY columns.
```


# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu-docs/blob/main/CLA.md).
